### PR TITLE
refactor: controllers use only mediator with no business logic

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/ProjePazariApplication.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/ProjePazariApplication.java
@@ -10,6 +10,5 @@ public class ProjePazariApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ProjePazariApplication.class, args);
-
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/ProjePazariApplication.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/ProjePazariApplication.java
@@ -10,5 +10,6 @@ public class ProjePazariApplication {
 
     public static void main(String[] args) {
         SpringApplication.run(ProjePazariApplication.class, args);
+
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deleteAllIndexes/DeleteAllIndexesCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deleteAllIndexes/DeleteAllIndexesCommand.java
@@ -1,0 +1,6 @@
+package com.iyte_yazilim.proje_pazari.application.commands.deleteAllIndexes;
+
+import com.iyte_yazilim.proje_pazari.application.common.ICommand;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+
+public record DeleteAllIndexesCommand() implements ICommand<ApiResponse<Void>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deleteAllIndexes/DeleteAllIndexesHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deleteAllIndexes/DeleteAllIndexesHandler.java
@@ -1,0 +1,26 @@
+package com.iyte_yazilim.proje_pazari.application.commands.deleteAllIndexes;
+
+import com.iyte_yazilim.proje_pazari.application.services.ElasticsearchSyncService;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "spring.data.elasticsearch.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class DeleteAllIndexesHandler
+        implements IRequestHandler<DeleteAllIndexesCommand, ApiResponse<Void>> {
+
+    private final ElasticsearchSyncService syncService;
+
+    @Override
+    public ApiResponse<Void> handle(DeleteAllIndexesCommand command) {
+        syncService.deleteAllIndexes();
+        return ApiResponse.success(null, "All indexes deleted");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexProjects/ReindexProjectsCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexProjects/ReindexProjectsCommand.java
@@ -1,0 +1,6 @@
+package com.iyte_yazilim.proje_pazari.application.commands.reindexProjects;
+
+import com.iyte_yazilim.proje_pazari.application.common.ICommand;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+
+public record ReindexProjectsCommand() implements ICommand<ApiResponse<Void>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexProjects/ReindexProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexProjects/ReindexProjectsHandler.java
@@ -1,0 +1,26 @@
+package com.iyte_yazilim.proje_pazari.application.commands.reindexProjects;
+
+import com.iyte_yazilim.proje_pazari.application.services.ElasticsearchSyncService;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "spring.data.elasticsearch.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class ReindexProjectsHandler
+        implements IRequestHandler<ReindexProjectsCommand, ApiResponse<Void>> {
+
+    private final ElasticsearchSyncService syncService;
+
+    @Override
+    public ApiResponse<Void> handle(ReindexProjectsCommand command) {
+        syncService.reindexAllProjects();
+        return ApiResponse.success(null, "Reindexing started");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexUsers/ReindexUsersCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexUsers/ReindexUsersCommand.java
@@ -1,0 +1,6 @@
+package com.iyte_yazilim.proje_pazari.application.commands.reindexUsers;
+
+import com.iyte_yazilim.proje_pazari.application.common.ICommand;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+
+public record ReindexUsersCommand() implements ICommand<ApiResponse<Void>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexUsers/ReindexUsersHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reindexUsers/ReindexUsersHandler.java
@@ -1,0 +1,26 @@
+package com.iyte_yazilim.proje_pazari.application.commands.reindexUsers;
+
+import com.iyte_yazilim.proje_pazari.application.services.ElasticsearchSyncService;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "spring.data.elasticsearch.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class ReindexUsersHandler
+        implements IRequestHandler<ReindexUsersCommand, ApiResponse<Void>> {
+
+    private final ElasticsearchSyncService syncService;
+
+    @Override
+    public ApiResponse<Void> handle(ReindexUsersCommand command) {
+        syncService.reindexAllUsers();
+        return ApiResponse.success(null, "Reindexing started");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandler.java
@@ -1,0 +1,46 @@
+package com.iyte_yazilim.proje_pazari.application.queries.downloadFile;
+
+import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DownloadFileHandler
+        implements IRequestHandler<DownloadFileQuery, ApiResponse<String>> {
+
+    private static final int DEFAULT_EXPIRY_MINUTES = 60;
+
+    private final FileStorageService fileStorageService;
+
+    @Override
+    public ApiResponse<String> handle(DownloadFileQuery query) {
+        String path = query.path();
+
+        if (path == null || path.isBlank()) {
+            return ApiResponse.badRequest("Invalid file path");
+        }
+
+        String decodedPath;
+        try {
+            decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.badRequest("Invalid file path encoding");
+        }
+
+        if (decodedPath.contains("..") || path.contains("..")) {
+            return ApiResponse.badRequest("Invalid file path");
+        }
+
+        if (!fileStorageService.fileExists(path)) {
+            return ApiResponse.notFound("File not found");
+        }
+
+        String presignedUrl = fileStorageService.getFileUrl(path, DEFAULT_EXPIRY_MINUTES);
+        return ApiResponse.success(presignedUrl, "File URL generated successfully");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileQuery.java
@@ -1,0 +1,6 @@
+package com.iyte_yazilim.proje_pazari.application.queries.downloadFile;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+
+public record DownloadFileQuery(String path) implements IRequest<ApiResponse<String>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectStatistics/GetProjectStatisticsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectStatistics/GetProjectStatisticsHandler.java
@@ -1,0 +1,27 @@
+package com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics;
+
+import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "spring.data.elasticsearch.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class GetProjectStatisticsHandler
+        implements IRequestHandler<GetProjectStatisticsQuery, ApiResponse<Map<String, Long>>> {
+
+    private final ProjectSearchService searchService;
+
+    @Override
+    public ApiResponse<Map<String, Long>> handle(GetProjectStatisticsQuery query) {
+        Map<String, Long> stats = searchService.getProjectStatistics();
+        return ApiResponse.success(stats, "Statistics retrieved successfully");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectStatistics/GetProjectStatisticsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectStatistics/GetProjectStatisticsQuery.java
@@ -1,0 +1,8 @@
+package com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import java.util.Map;
+
+public record GetProjectStatisticsQuery()
+        implements IRequest<ApiResponse<Map<String, Long>>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectStatistics/GetProjectStatisticsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectStatistics/GetProjectStatisticsQuery.java
@@ -4,5 +4,4 @@ import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import java.util.Map;
 
-public record GetProjectStatisticsQuery()
-        implements IRequest<ApiResponse<Map<String, Long>>> {}
+public record GetProjectStatisticsQuery() implements IRequest<ApiResponse<Map<String, Long>>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
@@ -1,0 +1,38 @@
+package com.iyte_yazilim.proje_pazari.application.queries.searchProjects;
+
+import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchPage;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "spring.data.elasticsearch.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class SearchProjectsHandler
+        implements IRequestHandler<SearchProjectsQuery, ApiResponse<List<ProjectDocument>>> {
+
+    private final ProjectSearchService searchService;
+
+    @Override
+    public ApiResponse<List<ProjectDocument>> handle(SearchProjectsQuery query) {
+        Pageable pageable = PageRequest.of(query.page(), query.size());
+        SearchPage<ProjectDocument> results =
+                searchService.advancedSearch(query.q(), query.status(), query.tags(), pageable);
+
+        List<ProjectDocument> documents =
+                results.getContent().stream().map(SearchHit::getContent).toList();
+
+        return ApiResponse.success(documents, "Projects retrieved successfully");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsQuery.java
@@ -1,0 +1,18 @@
+package com.iyte_yazilim.proje_pazari.application.queries.searchProjects;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record SearchProjectsQuery(
+        @NotBlank @Size(min = 2, max = 100) String q,
+        String status,
+        List<String> tags,
+        @Min(0) int page,
+        @Min(1) @Max(100) int size)
+        implements IRequest<ApiResponse<List<ProjectDocument>>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/suggestProjects/SuggestProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/suggestProjects/SuggestProjectsHandler.java
@@ -1,6 +1,5 @@
 package com.iyte_yazilim.proje_pazari.application.queries.suggestProjects;
 
-
 import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/suggestProjects/SuggestProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/suggestProjects/SuggestProjectsHandler.java
@@ -1,0 +1,28 @@
+package com.iyte_yazilim.proje_pazari.application.queries.suggestProjects;
+
+
+import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+        name = "spring.data.elasticsearch.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class SuggestProjectsHandler
+        implements IRequestHandler<SuggestProjectsQuery, ApiResponse<List<String>>> {
+
+    private final ProjectSearchService searchService;
+
+    @Override
+    public ApiResponse<List<String>> handle(SuggestProjectsQuery query) {
+        List<String> suggestions = searchService.getSuggestions(query.q());
+        return ApiResponse.success(suggestions, "Suggestions retrieved successfully");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/suggestProjects/SuggestProjectsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/suggestProjects/SuggestProjectsQuery.java
@@ -1,0 +1,10 @@
+package com.iyte_yazilim.proje_pazari.application.queries.suggestProjects;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.util.List;
+
+public record SuggestProjectsQuery(@NotBlank @Size(min = 1, max = 100) String q)
+        implements IRequest<ApiResponse<List<String>>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IRequest.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IRequest.java
@@ -1,6 +1,6 @@
 package com.iyte_yazilim.proje_pazari.domain.interfaces;
-/**
 
+/**
  * Marker interface for CQRS requests (commands and queries).
  *
  * <p>All commands and queries in the system should implement this interface. The type parameter
@@ -16,7 +16,7 @@ package com.iyte_yazilim.proje_pazari.domain.interfaces;
  * }</pre>
  *
  * @param <TResponse> the type of response expected from handling this request
- * @author IYTE Yazılım Proje Pazarı Team 
+ * @author IYTE Yazılım Proje Pazarı Team
  * @version 1.0
  * @since 2024-01-01
  * @see IRequestHandler

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IRequest.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IRequest.java
@@ -1,6 +1,6 @@
 package com.iyte_yazilim.proje_pazari.domain.interfaces;
-
 /**
+
  * Marker interface for CQRS requests (commands and queries).
  *
  * <p>All commands and queries in the system should implement this interface. The type parameter
@@ -16,7 +16,7 @@ package com.iyte_yazilim.proje_pazari.domain.interfaces;
  * }</pre>
  *
  * @param <TResponse> the type of response expected from handling this request
- * @author IYTE Yazılım Topluluğu
+ * @author IYTE Yazılım Proje Pazarı Team 
  * @version 1.0
  * @since 2024-01-01
  * @see IRequestHandler

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -1,6 +1,8 @@
 package com.iyte_yazilim.proje_pazari.presentation.config;
 
+import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
@@ -95,6 +97,20 @@ public class GlobalExceptionHandler {
         ApiResponse<Void> response =
                 ApiResponse.validationError(messageService.getMessage("error.validation"));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(ValidationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(ValidationException ex) {
+        log.error("Validation error: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.validationError(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(FileStorageException.class)
+    public ResponseEntity<ApiResponse<Void>> handleFileStorageException(FileStorageException ex) {
+        log.debug("File storage error: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
@@ -95,8 +95,7 @@ public class AdminController extends BaseController {
                         responseCode = "403",
                         description = "Forbidden - ADMIN role required")
             })
-    public ResponseEntity<ApiResponse<Void>> promoteToProjectOwner(
-            @PathVariable String userId) {
+    public ResponseEntity<ApiResponse<Void>> promoteToProjectOwner(@PathVariable String userId) {
         return send(new PromoteToProjectOwnerCommand(userId));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
@@ -1,7 +1,6 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import com.iyte_yazilim.proje_pazari.application.commands.promoteToProjectOwner.PromoteToProjectOwnerCommand;
-import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -10,8 +9,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -22,15 +19,12 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/admin")
-@RequiredArgsConstructor
 @Tag(
         name = "Admin",
         description = "Admin-only endpoints for user and system management. Requires ADMIN role.")
 @SecurityRequirement(name = "Bearer Authentication")
 @PreAuthorize("hasRole('ADMIN')")
-public class AdminController {
-
-    private final IMediator mediator;
+public class AdminController extends BaseController {
 
     @PostMapping("/users/{userId}/promote-to-project-owner")
     @Operation(
@@ -101,19 +95,8 @@ public class AdminController {
                         responseCode = "403",
                         description = "Forbidden - ADMIN role required")
             })
-    public ResponseEntity<ApiResponse<Void>> promoteToProjectOwner(@PathVariable String userId) {
-
-        PromoteToProjectOwnerCommand command = new PromoteToProjectOwnerCommand(userId);
-        ApiResponse<Void> response = mediator.send(command);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case VALIDATION_ERROR -> HttpStatus.BAD_REQUEST;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+    public ResponseEntity<ApiResponse<Void>> promoteToProjectOwner(
+            @PathVariable String userId) {
+        return send(new PromoteToProjectOwnerCommand(userId));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
@@ -2,7 +2,6 @@ package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import com.iyte_yazilim.proje_pazari.application.commands.loginUser.LoginUserCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.registerUser.RegisterUserCommand;
-import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.domain.models.results.LoginUserResult;
 import com.iyte_yazilim.proje_pazari.domain.models.results.RegisterUserResult;
@@ -12,8 +11,6 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -58,15 +55,12 @@ import org.springframework.web.bind.annotation.*;
  */
 @RestController
 @RequestMapping("/api/v1/auth")
-@RequiredArgsConstructor
 @Tag(
         name = "Authentication",
         description =
                 "Authentication endpoints for user registration and login. "
                         + "These endpoints are public and do not require authentication.")
-public class AuthController {
-
-    private final IMediator mediator;
+public class AuthController extends BaseController {
 
     @PostMapping("/register")
     @Operation(
@@ -140,17 +134,7 @@ public class AuthController {
                         """)))
     public ResponseEntity<ApiResponse<RegisterUserResult>> register(
             @RequestBody RegisterUserCommand command) {
-
-        ApiResponse<RegisterUserResult> response = mediator.send(command);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case CREATED -> HttpStatus.CREATED;
-                    case BAD_REQUEST -> HttpStatus.BAD_REQUEST;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+        return send(command);
     }
 
     @PostMapping("/login")
@@ -222,16 +206,6 @@ public class AuthController {
                         """)))
     public ResponseEntity<ApiResponse<LoginUserResult>> login(
             @RequestBody LoginUserCommand command) {
-
-        ApiResponse<LoginUserResult> response = mediator.send(command);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case BAD_REQUEST -> HttpStatus.BAD_REQUEST;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+        return send(command);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
@@ -1,13 +1,47 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
+import com.iyte_yazilim.proje_pazari.application.common.IMediator;
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.presentation.mappers.IRequestMapper;
 import com.iyte_yazilim.proje_pazari.presentation.security.UserPrincipal;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.RestController;
 
-@RestController
 public abstract class BaseController {
 
-    // Helper method to get current user from JWT
+    @Autowired
+    protected IMediator mediator;
+
+    @Autowired
+    protected IRequestMapper requestMapper;
+
+    protected <T> ResponseEntity<ApiResponse<T>> send(IRequest<ApiResponse<T>> request) {
+        ApiResponse<T> response = mediator.send(request);
+        HttpStatus status = resolveHttpStatus(response.getCode());
+        return ResponseEntity.status(status).body(response);
+    }
+
+    protected HttpStatus resolveHttpStatus(ResponseCode code) {
+        return switch (code) {
+            case SUCCESS -> HttpStatus.OK;
+            case CREATED -> HttpStatus.CREATED;
+            case ACCEPTED -> HttpStatus.OK;
+            case NO_CONTENT -> HttpStatus.NO_CONTENT;
+            case BAD_REQUEST -> HttpStatus.BAD_REQUEST;
+            case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
+            case FORBIDDEN -> HttpStatus.FORBIDDEN;
+            case NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case CONFLICT -> HttpStatus.CONFLICT;
+            case VALIDATION_ERROR -> HttpStatus.BAD_REQUEST;
+            case INTERNAL_SERVER_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
+        };
+    }
+
     protected UserPrincipal getCurrentUser(Authentication authentication) {
         if (authentication == null || authentication.getPrincipal() == null) {
             throw new IllegalStateException("No authenticated user found");
@@ -25,5 +59,33 @@ public abstract class BaseController {
 
     protected String getCurrentUserRole(Authentication authentication) {
         return getCurrentUser(authentication).getRole();
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> ResponseEntity<ApiResponse<T>> send(
+            Class<? extends IRequest<ApiResponse<T>>> requestClass,
+            Map<String, String> pathVariables,
+            Map<String, String> queryParams,
+            Object body,
+            Authentication auth) {
+        IRequest<ApiResponse<T>> request =
+                (IRequest<ApiResponse<T>>)
+                        requestMapper.map(requestClass, pathVariables, queryParams, body, auth);
+        return send(request);
+    }
+
+    @SuppressWarnings("unchecked")
+    protected <T> ResponseEntity<ApiResponse<T>> send(
+            Class<? extends IRequest<ApiResponse<T>>> requestClass,
+            Map<String, String> pathVariables,
+            Map<String, String> queryParams,
+            Object body,
+            Authentication auth,
+            Map<String, Object> extraFields) {
+        IRequest<ApiResponse<T>> request =
+                (IRequest<ApiResponse<T>>)
+                        requestMapper.map(
+                                requestClass, pathVariables, queryParams, body, auth, extraFields);
+        return send(request);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
@@ -28,7 +28,7 @@ public abstract class BaseController {
         return switch (code) {
             case SUCCESS -> HttpStatus.OK;
             case CREATED -> HttpStatus.CREATED;
-            case ACCEPTED -> HttpStatus.OK;
+            case ACCEPTED -> HttpStatus.ACCEPTED;
             case NO_CONTENT -> HttpStatus.NO_CONTENT;
             case BAD_REQUEST -> HttpStatus.BAD_REQUEST;
             case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
@@ -14,11 +14,9 @@ import org.springframework.security.core.Authentication;
 
 public abstract class BaseController {
 
-    @Autowired
-    protected IMediator mediator;
+    @Autowired protected IMediator mediator;
 
-    @Autowired
-    protected IRequestMapper requestMapper;
+    @Autowired protected IRequestMapper requestMapper;
 
     protected <T> ResponseEntity<ApiResponse<T>> send(IRequest<ApiResponse<T>> request) {
         ApiResponse<T> response = mediator.send(request);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ElasticsearchAdminController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ElasticsearchAdminController.java
@@ -1,9 +1,11 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
-import com.iyte_yazilim.proje_pazari.application.services.ElasticsearchSyncService;
+import com.iyte_yazilim.proje_pazari.application.commands.deleteAllIndexes.DeleteAllIndexesCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.reindexProjects.ReindexProjectsCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.reindexUsers.ReindexUsersCommand;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,30 +15,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/admin/elasticsearch")
 @PreAuthorize("hasRole('ADMIN')")
-@RequiredArgsConstructor
 @ConditionalOnProperty(
         name = "spring.data.elasticsearch.enabled",
         havingValue = "true",
         matchIfMissing = true)
-public class ElasticsearchAdminController {
-
-    private final ElasticsearchSyncService syncService;
+public class ElasticsearchAdminController extends BaseController {
 
     @PostMapping("/reindex/projects")
-    public ApiResponse<Void> reindexProjects() {
-        syncService.reindexAllProjects();
-        return ApiResponse.success(null, "Reindexing started");
+    public ResponseEntity<ApiResponse<Void>> reindexProjects() {
+        return send(new ReindexProjectsCommand());
     }
 
     @PostMapping("/reindex/users")
-    public ApiResponse<Void> reindexUsers() {
-        syncService.reindexAllUsers();
-        return ApiResponse.success(null, "Reindexing started");
+    public ResponseEntity<ApiResponse<Void>> reindexUsers() {
+        return send(new ReindexUsersCommand());
     }
 
     @DeleteMapping("/indexes")
-    public ApiResponse<Void> deleteAllIndexes() {
-        syncService.deleteAllIndexes();
-        return ApiResponse.success(null, "All indexes deleted");
+    public ResponseEntity<ApiResponse<Void>> deleteAllIndexes() {
+        return send(new DeleteAllIndexesCommand());
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -1,12 +1,10 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
-import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.application.queries.downloadFile.DownloadFileQuery;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -14,20 +12,14 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/files")
-@RequiredArgsConstructor
 @Tag(name = "Files", description = "File serving endpoints")
-@Slf4j
-public class FileController {
-
-    private static final int DEFAULT_EXPIRY_MINUTES = 60;
-
-    private final FileStorageService fileStorageService;
+public class FileController extends BaseController {
 
     @GetMapping("/{*path}")
     @Operation(
+            "Redirects to presigned URL for file access. "
             summary = "Download file",
             description =
-                    "Redirects to presigned URL for file access. "
                             + "Supports images, PDFs, and documents.")
     @ApiResponses(
             value = {
@@ -39,41 +31,15 @@ public class FileController {
                         description = "File not found")
             })
     public ResponseEntity<?> downloadFile(@PathVariable String path) {
-        try {
-            // Validate path - check for path traversal attacks including encoded variants
-            if (path == null || path.isBlank()) {
-                return ResponseEntity.badRequest().body("Invalid file path");
-            }
+        ApiResponse<String> response = mediator.send(new DownloadFileQuery(path));
+        HttpStatus status = resolveHttpStatus(response.getCode());
 
-            // Decode URL-encoded characters and normalize path for security validation
-            String decodedPath;
-            try {
-                decodedPath =
-                        java.net.URLDecoder.decode(path, java.nio.charset.StandardCharsets.UTF_8);
-            } catch (IllegalArgumentException e) {
-                return ResponseEntity.badRequest().body("Invalid file path encoding");
-            }
-
-            // Check for path traversal patterns (both encoded and decoded)
-            if (decodedPath.contains("..") || path.contains("..")) {
-                return ResponseEntity.badRequest().body("Invalid file path");
-            }
-
-            // Check if file exists
-            if (!fileStorageService.fileExists(path)) {
-                return ResponseEntity.notFound().build();
-            }
-
-            // Generate presigned URL and redirect
-            String presignedUrl = fileStorageService.getFileUrl(path, DEFAULT_EXPIRY_MINUTES);
-
+        if (status.is2xxSuccessful()) {
             return ResponseEntity.status(HttpStatus.FOUND)
-                    .header(HttpHeaders.LOCATION, presignedUrl)
+                    .header(HttpHeaders.LOCATION, response.getData())
                     .build();
-
-        } catch (FileStorageException e) {
-            log.debug("File not found: {}", path);
-            return ResponseEntity.notFound().build();
         }
+
+        return ResponseEntity.status(status).body(response);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -18,7 +18,8 @@ public class FileController extends BaseController {
     @GetMapping("/{*path}")
     @Operation(
             summary = "Download file",
-            description = "Redirects to presigned URL for file access. "
+            description =
+                    "Redirects to presigned URL for file access. "
                             + "Supports images, PDFs, and documents.")
     @ApiResponses(
             value = {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -17,9 +17,8 @@ public class FileController extends BaseController {
 
     @GetMapping("/{*path}")
     @Operation(
-            "Redirects to presigned URL for file access. "
             summary = "Download file",
-            description =
+            description = "Redirects to presigned URL for file access. "
                             + "Supports images, PDFs, and documents.")
     @ApiResponses(
             value = {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
@@ -1,7 +1,6 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import com.iyte_yazilim.proje_pazari.application.commands.createProject.CreateProjectCommand;
-import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.domain.models.results.CreateProjectCommandResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -11,24 +10,20 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/v1/projects")
-@RequiredArgsConstructor
 @Tag(
         name = "Projects",
         description =
                 "Project management endpoints. "
                         + "Allows users to create, read, update, and delete projects.")
-public class ProjectController {
-
-    private final IMediator mediator;
+public class ProjectController extends BaseController {
 
     @PostMapping
     @PreAuthorize("isAuthenticated() and hasRole('PROJECT_OWNER')")
@@ -125,19 +120,7 @@ public class ProjectController {
                         }
                         """)))
     public ResponseEntity<ApiResponse<CreateProjectCommandResult>> createProject(
-            @RequestBody CreateProjectCommand command) {
-
-        ApiResponse<CreateProjectCommandResult> response = mediator.send(command);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case CREATED -> HttpStatus.CREATED;
-                    case BAD_REQUEST -> HttpStatus.BAD_REQUEST;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    case INTERNAL_SERVER_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+            @RequestBody CreateProjectCommand command, Authentication auth) {
+        return send(CreateProjectCommand.class, null, null, command, auth);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
@@ -1,72 +1,51 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
-import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics.GetProjectStatisticsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.searchProjects.SearchProjectsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.suggestProjects.SuggestProjectsQuery;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.elasticsearch.core.SearchHit;
-import org.springframework.data.elasticsearch.core.SearchPage;
-import org.springframework.validation.annotation.Validated;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/v1/search")
-@Validated
 @ConditionalOnProperty(
         name = "spring.data.elasticsearch.enabled",
         havingValue = "true",
         matchIfMissing = true)
 @Tag(name = "Search", description = "Elasticsearch-powered search endpoints for projects")
 @SecurityRequirement(name = "Bearer Authentication")
-public class SearchController {
-
-    private final ProjectSearchService searchService;
+public class SearchController extends BaseController {
 
     @GetMapping("/projects")
     @SecurityRequirement(name = "Bearer Authentication")
-    public ApiResponse<List<ProjectDocument>> searchProjects(
-            @RequestParam @NotBlank @Size(min = 2, max = 100) String q,
+    public ResponseEntity<ApiResponse<List<ProjectDocument>>> searchProjects(
+            @RequestParam String q,
             @RequestParam(required = false) String status,
             @RequestParam(required = false) List<String> tags,
-            @RequestParam(defaultValue = "0") @Min(0) int page,
-            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size) {
-        Pageable pageable = PageRequest.of(page, size);
-        SearchPage<ProjectDocument> results =
-                searchService.advancedSearch(q, status, tags, pageable);
-
-        List<ProjectDocument> documents =
-                results.getContent().stream().map(SearchHit::getContent).toList();
-
-        return ApiResponse.success(documents, "Projects retrieved successfully");
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        return send(new SearchProjectsQuery(q, status, tags, page, size));
     }
 
     @GetMapping("/projects/suggest")
     @SecurityRequirement(name = "Bearer Authentication")
-    public ApiResponse<List<String>> suggestProjects(
-            @RequestParam @NotBlank @Size(min = 1, max = 100) String q) {
-        List<String> suggestions = searchService.getSuggestions(q);
-        return ApiResponse.success(suggestions, "Suggestions retrieved successfully");
+    public ResponseEntity<ApiResponse<List<String>>> suggestProjects(@RequestParam String q) {
+        return send(new SuggestProjectsQuery(q));
     }
 
     @GetMapping("/projects/statistics")
     @SecurityRequirement(name = "Bearer Authentication")
-    public ApiResponse<Map<String, Long>> getStatistics() {
-        Map<String, Long> stats = searchService.getProjectStatistics();
-        return ApiResponse.success(stats, "Statistics retrieved successfully");
+    public ResponseEntity<ApiResponse<Map<String, Long>>> getStatistics() {
+        return send(new GetProjectStatisticsQuery());
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
@@ -61,8 +61,7 @@ public class UserController extends BaseController {
                         responseCode = "404",
                         description = "User not found")
             })
-    public ResponseEntity<ApiResponse<UserProfileDTO>> getUserProfile(
-            @PathVariable String userId) {
+    public ResponseEntity<ApiResponse<UserProfileDTO>> getUserProfile(@PathVariable String userId) {
         return send(new GetUserProfileQuery(userId));
     }
 
@@ -131,12 +130,7 @@ public class UserController extends BaseController {
                     MultipartFile file,
             Authentication auth) {
         return send(
-                UploadProfilePictureCommand.class,
-                null,
-                null,
-                null,
-                auth,
-                Map.of("file", file));
+                UploadProfilePictureCommand.class, null, null, null, auth, Map.of("file", file));
     }
 
     @PutMapping("/me/password")

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
@@ -32,6 +32,7 @@ import org.springframework.web.multipart.MultipartFile;
                         + "Most endpoints require authentication.")
 public class UserController extends BaseController {
 
+    @GetMapping
     @PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
     @SecurityRequirement(name = "Bearer Authentication")
     @Operation(summary = "Get all users", description = "Retrieves a list of all users")

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
@@ -4,7 +4,6 @@ import com.iyte_yazilim.proje_pazari.application.commands.changePassword.ChangeP
 import com.iyte_yazilim.proje_pazari.application.commands.deactivateAccount.DeactivateAccountCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.updateUserProfile.UpdateUserProfileCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.uploadProfilePicture.UploadProfilePictureCommand;
-import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserProfileDTO;
 import com.iyte_yazilim.proje_pazari.application.queries.getAllUsers.GetAllUsersQuery;
@@ -16,8 +15,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
+import java.util.Map;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.Authentication;
@@ -26,7 +24,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/users")
-@RequiredArgsConstructor
 @Tag(
         name = "User",
         description =
@@ -34,8 +31,6 @@ import org.springframework.web.multipart.MultipartFile;
                         + "profile picture upload, and account deactivation. "
                         + "Most endpoints require authentication.")
 public class UserController extends BaseController {
-
-    private final IMediator mediator;
 
     @PreAuthorize("isAuthenticated() and hasRole('ADMIN')")
     @SecurityRequirement(name = "Bearer Authentication")
@@ -50,17 +45,7 @@ public class UserController extends BaseController {
                         description = "Unauthorized")
             })
     public ResponseEntity<ApiResponse<List<UserDto>>> getAllUsers() {
-
-        ApiResponse<List<UserDto>> response = mediator.send(new GetAllUsersQuery());
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+        return send(new GetAllUsersQuery());
     }
 
     @GetMapping("/{userId}")
@@ -76,17 +61,9 @@ public class UserController extends BaseController {
                         responseCode = "404",
                         description = "User not found")
             })
-    public ResponseEntity<ApiResponse<UserProfileDTO>> getUserProfile(@PathVariable String userId) {
-        ApiResponse<UserProfileDTO> response = mediator.send(new GetUserProfileQuery(userId));
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+    public ResponseEntity<ApiResponse<UserProfileDTO>> getUserProfile(
+            @PathVariable String userId) {
+        return send(new GetUserProfileQuery(userId));
     }
 
     @PreAuthorize("isAuthenticated()")
@@ -108,29 +85,7 @@ public class UserController extends BaseController {
             })
     public ResponseEntity<ApiResponse<UserDto>> updateProfile(
             @RequestBody @Valid UpdateUserProfileCommand command, Authentication auth) {
-        String userId = getCurrentUserId(auth);
-
-        UpdateUserProfileCommand updatedCommand =
-                new UpdateUserProfileCommand(
-                        userId,
-                        command.firstName(),
-                        command.lastName(),
-                        command.description(),
-                        command.linkedinUrl(),
-                        command.githubUrl(),
-                        command.preferredLanguage());
-
-        ApiResponse<UserDto> response = mediator.send(updatedCommand);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case VALIDATION_ERROR -> HttpStatus.BAD_REQUEST;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+        return send(UpdateUserProfileCommand.class, null, null, command, auth);
     }
 
     @PostMapping(value = "/me/profile-picture", consumes = "multipart/form-data")
@@ -175,21 +130,13 @@ public class UserController extends BaseController {
                     @RequestParam("file")
                     MultipartFile file,
             Authentication auth) {
-        String userId = getCurrentUserId(auth);
-
-        UploadProfilePictureCommand command = new UploadProfilePictureCommand(userId, file);
-
-        ApiResponse<String> response = mediator.send(command);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case VALIDATION_ERROR -> HttpStatus.BAD_REQUEST;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    default -> HttpStatus.INTERNAL_SERVER_ERROR;
-                };
-
-        return ResponseEntity.status(status).body(response);
+        return send(
+                UploadProfilePictureCommand.class,
+                null,
+                null,
+                null,
+                auth,
+                Map.of("file", file));
     }
 
     @PutMapping("/me/password")
@@ -212,26 +159,7 @@ public class UserController extends BaseController {
             })
     public ResponseEntity<ApiResponse<Void>> changePassword(
             @RequestBody @Valid ChangePasswordCommand command, Authentication auth) {
-        String userId = getCurrentUserId(auth);
-
-        ChangePasswordCommand updatedCommand =
-                new ChangePasswordCommand(
-                        userId,
-                        command.currentPassword(),
-                        command.newPassword(),
-                        command.confirmPassword());
-
-        ApiResponse<Void> response = mediator.send(updatedCommand);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case VALIDATION_ERROR -> HttpStatus.BAD_REQUEST;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+        return send(ChangePasswordCommand.class, null, null, command, auth);
     }
 
     @DeleteMapping("/me")
@@ -251,19 +179,8 @@ public class UserController extends BaseController {
             })
     public ResponseEntity<ApiResponse<Void>> deactivateAccount(
             @RequestParam(required = false) String reason, Authentication auth) {
-        String userId = getCurrentUserId(auth);
-
-        DeactivateAccountCommand command = new DeactivateAccountCommand(userId, reason);
-
-        ApiResponse<Void> response = mediator.send(command);
-
-        HttpStatus status =
-                switch (response.getCode()) {
-                    case SUCCESS -> HttpStatus.OK;
-                    case NOT_FOUND -> HttpStatus.NOT_FOUND;
-                    default -> HttpStatus.OK;
-                };
-
-        return ResponseEntity.status(status).body(response);
+        Map<String, String> queryParams = new java.util.HashMap<>();
+        queryParams.put("reason", reason);
+        return send(DeactivateAccountCommand.class, null, queryParams, null, auth);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
@@ -139,7 +139,9 @@ public class AutoRequestMapper implements IRequestMapper {
             return ctor.newInstance(args);
         } catch (Exception e) {
             throw new RuntimeException(
-                    "Failed to construct " + requestClass.getSimpleName() + " via canonical constructor",
+                    "Failed to construct "
+                            + requestClass.getSimpleName()
+                            + " via canonical constructor",
                     e);
         }
     }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
@@ -21,10 +21,9 @@ public class AutoRequestMapper implements IRequestMapper {
 
     private final ObjectMapper objectMapper;
 
-    public AutoRequestMapper(ObjectMapper objectMapper) {
+    public AutoRequestMapper() {
         this.objectMapper =
-                objectMapper
-                        .copy()
+                new ObjectMapper()
                         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
@@ -1,0 +1,177 @@
+package com.iyte_yazilim.proje_pazari.presentation.mappers;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.presentation.security.UserPrincipal;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.RecordComponent;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+@Component
+public class AutoRequestMapper implements IRequestMapper {
+
+    private static final Set<String> AUTH_USER_FIELDS =
+            Set.of("userId", "ownerId", "authenticatedUserId", "requesterId", "operatorId");
+
+    private final ObjectMapper objectMapper;
+
+    public AutoRequestMapper(ObjectMapper objectMapper) {
+        this.objectMapper =
+                objectMapper
+                        .copy()
+                        .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+    }
+
+    @Override
+    public <T extends IRequest<?>> T map(
+            Class<T> requestClass,
+            Map<String, String> pathVariables,
+            Map<String, String> queryParams,
+            Object body,
+            Authentication auth) {
+        return map(requestClass, pathVariables, queryParams, body, auth, null);
+    }
+
+    @Override
+    public <T extends IRequest<?>> T map(
+            Class<T> requestClass,
+            Map<String, String> pathVariables,
+            Map<String, String> queryParams,
+            Object body,
+            Authentication auth,
+            Map<String, Object> extraFields) {
+
+        if (hasMultipartField(requestClass)) {
+            return buildViaConstructor(
+                    requestClass, pathVariables, queryParams, body, auth, extraFields);
+        }
+
+        Map<String, Object> dataMap = new HashMap<>();
+
+        if (body != null) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> bodyMap = objectMapper.convertValue(body, Map.class);
+            dataMap.putAll(bodyMap);
+        }
+
+        if (queryParams != null) {
+            dataMap.putAll(queryParams);
+        }
+
+        if (pathVariables != null) {
+            dataMap.putAll(pathVariables);
+        }
+
+        injectAuthFields(requestClass, dataMap, auth);
+
+        if (extraFields != null) {
+            dataMap.putAll(extraFields);
+        }
+
+        return objectMapper.convertValue(dataMap, requestClass);
+    }
+
+    private <T> boolean hasMultipartField(Class<T> requestClass) {
+        if (!requestClass.isRecord()) {
+            return false;
+        }
+        for (RecordComponent rc : requestClass.getRecordComponents()) {
+            if (MultipartFile.class.isAssignableFrom(rc.getType())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private <T extends IRequest<?>> T buildViaConstructor(
+            Class<T> requestClass,
+            Map<String, String> pathVariables,
+            Map<String, String> queryParams,
+            Object body,
+            Authentication auth,
+            Map<String, Object> extraFields) {
+
+        Map<String, Object> dataMap = new HashMap<>();
+
+        if (body != null && !(body instanceof MultipartFile)) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> bodyMap = objectMapper.convertValue(body, Map.class);
+            dataMap.putAll(bodyMap);
+        }
+
+        if (queryParams != null) {
+            dataMap.putAll(queryParams);
+        }
+
+        if (pathVariables != null) {
+            dataMap.putAll(pathVariables);
+        }
+
+        injectAuthFields(requestClass, dataMap, auth);
+
+        if (extraFields != null) {
+            dataMap.putAll(extraFields);
+        }
+
+        RecordComponent[] components = requestClass.getRecordComponents();
+        Class<?>[] paramTypes = new Class<?>[components.length];
+        Object[] args = new Object[components.length];
+
+        for (int i = 0; i < components.length; i++) {
+            paramTypes[i] = components[i].getType();
+            String name = components[i].getName();
+            Object value = dataMap.get(name);
+
+            if (value != null && !paramTypes[i].isAssignableFrom(value.getClass())) {
+                args[i] = objectMapper.convertValue(value, paramTypes[i]);
+            } else {
+                args[i] = value;
+            }
+        }
+
+        try {
+            Constructor<T> ctor = requestClass.getDeclaredConstructor(paramTypes);
+            return ctor.newInstance(args);
+        } catch (Exception e) {
+            throw new RuntimeException(
+                    "Failed to construct " + requestClass.getSimpleName() + " via canonical constructor",
+                    e);
+        }
+    }
+
+    private void injectAuthFields(
+            Class<?> requestClass, Map<String, Object> dataMap, Authentication auth) {
+        if (auth == null) {
+            return;
+        }
+
+        String currentUserId = getUserIdFromAuth(auth);
+        if (currentUserId == null) {
+            return;
+        }
+
+        if (!requestClass.isRecord()) {
+            return;
+        }
+
+        for (RecordComponent rc : requestClass.getRecordComponents()) {
+            if (AUTH_USER_FIELDS.contains(rc.getName())) {
+                dataMap.put(rc.getName(), currentUserId);
+            }
+        }
+    }
+
+    private String getUserIdFromAuth(Authentication auth) {
+        Object principal = auth.getPrincipal();
+        if (principal instanceof UserPrincipal userPrincipal) {
+            return userPrincipal.getUserId();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/IRequestMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/IRequestMapper.java
@@ -1,0 +1,23 @@
+package com.iyte_yazilim.proje_pazari.presentation.mappers;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import java.util.Map;
+import org.springframework.security.core.Authentication;
+
+public interface IRequestMapper {
+
+    <T extends IRequest<?>> T map(
+            Class<T> requestClass,
+            Map<String, String> pathVariables,
+            Map<String, String> queryParams,
+            Object body,
+            Authentication auth);
+
+    <T extends IRequest<?>> T map(
+            Class<T> requestClass,
+            Map<String, String> pathVariables,
+            Map<String, String> queryParams,
+            Object body,
+            Authentication auth,
+            Map<String, Object> extraFields);
+}

--- a/src/test/java/ApiResponseSerializationTest.java
+++ b/src/test/java/ApiResponseSerializationTest.java
@@ -1,12 +1,9 @@
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.iyte_yazilim.proje_pazari.ProjePazariApplication;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest(classes = ProjePazariApplication.class)
 public class ApiResponseSerializationTest {
 
     private final ObjectMapper om = new ObjectMapper();

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminControllerTest.java
@@ -8,12 +8,13 @@ import com.iyte_yazilim.proje_pazari.application.commands.promoteToProjectOwner.
 import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
-import org.junit.jupiter.api.BeforeEach;
+import com.iyte_yazilim.proje_pazari.presentation.mappers.IRequestMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
@@ -24,12 +25,9 @@ class AdminControllerTest {
 
     @Mock private IMediator mediator;
 
-    private AdminController adminController;
+    @Mock private IRequestMapper requestMapper;
 
-    @BeforeEach
-    void setUp() {
-        adminController = new AdminController(mediator);
-    }
+    @InjectMocks private AdminController adminController;
 
     @Nested
     @DisplayName("promoteToProjectOwner() method")

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
@@ -10,7 +10,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
-import com.iyte_yazilim.proje_pazari.presentation.mappers.IRequestMapper;
 import com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics.GetProjectStatisticsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.searchProjects.SearchProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.suggestProjects.SuggestProjectsQuery;
@@ -18,6 +17,7 @@ import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
+import com.iyte_yazilim.proje_pazari.presentation.mappers.IRequestMapper;
 import com.iyte_yazilim.proje_pazari.presentation.security.JwtUtil;
 import java.time.LocalDateTime;
 import java.util.Collections;
@@ -263,9 +263,7 @@ class SearchControllerTest {
         @DisplayName("Should return bad request when size exceeds maximum")
         void shouldReturnBadRequestWhenSizeExceedsMaximum() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenThrow(
-                            new ValidationException(
-                                    "size: must be less than or equal to 100"));
+                    .thenThrow(new ValidationException("size: must be less than or equal to 100"));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "java").param("size", "101"))
                     .andExpect(status().isBadRequest());
@@ -311,8 +309,7 @@ class SearchControllerTest {
             when(mediator.send(any(SuggestProjectsQuery.class)))
                     .thenReturn(
                             ApiResponse.success(
-                                    Collections.emptyList(),
-                                    "Suggestions retrieved successfully"));
+                                    Collections.emptyList(), "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "xyz"))
                     .andExpect(status().isOk())
@@ -327,8 +324,7 @@ class SearchControllerTest {
             when(mediator.send(any(SuggestProjectsQuery.class)))
                     .thenReturn(
                             ApiResponse.success(
-                                    List.of("Java Project"),
-                                    "Suggestions retrieved successfully"));
+                                    List.of("Java Project"), "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "j"))
                     .andExpect(status().isOk())
@@ -384,8 +380,7 @@ class SearchControllerTest {
         void shouldReturnStatisticsSuccessfully() throws Exception {
             Map<String, Long> stats = Map.of("ACTIVE", 10L, "COMPLETED", 5L, "DRAFT", 3L);
             when(mediator.send(any(GetProjectStatisticsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(stats, "Statistics retrieved successfully"));
+                    .thenReturn(ApiResponse.success(stats, "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())
@@ -405,8 +400,7 @@ class SearchControllerTest {
             when(mediator.send(any(GetProjectStatisticsQuery.class)))
                     .thenReturn(
                             ApiResponse.success(
-                                    Collections.emptyMap(),
-                                    "Statistics retrieved successfully"));
+                                    Collections.emptyMap(), "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
@@ -2,17 +2,20 @@ package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.iyte_yazilim.proje_pazari.application.common.IMediator;
+import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
+import com.iyte_yazilim.proje_pazari.presentation.mappers.IRequestMapper;
+import com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics.GetProjectStatisticsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.searchProjects.SearchProjectsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.suggestProjects.SuggestProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
 import com.iyte_yazilim.proje_pazari.presentation.security.JwtUtil;
@@ -24,15 +27,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.elasticsearch.core.SearchHit;
-import org.springframework.data.elasticsearch.core.SearchHitSupport;
-import org.springframework.data.elasticsearch.core.SearchHits;
-import org.springframework.data.elasticsearch.core.SearchHitsImpl;
-import org.springframework.data.elasticsearch.core.SearchPage;
-import org.springframework.data.elasticsearch.core.TotalHitsRelation;
 import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -46,27 +43,24 @@ class SearchControllerTest {
 
     @Autowired private MockMvc mockMvc;
 
-    @MockitoBean private ProjectSearchService searchService;
+    @MockitoBean private IMediator mediator;
 
-    private ProjectDocument sampleProject;
+    @MockitoBean private IRequestMapper requestMapper;
 
     @MockitoBean private JwtUtil jwtUtil;
 
-    // 2. Mock the standard UserDetailsService
     @MockitoBean private UserDetailsService userDetailsService;
 
-    // 3. Mock the AuthenticationProvider (if your SecurityConfig uses it)
     @MockitoBean private AuthenticationProvider authenticationProvider;
 
-    // 4. Mock MessageService required by GlobalExceptionHandler
     @MockitoBean private MessageService messageService;
 
-    // 5. Mock UserRepository required by UserLocaleInterceptor
     @MockitoBean private UserRepository userRepository;
+
+    private ProjectDocument sampleProject;
 
     @BeforeEach
     void setUp() {
-        // Setup MessageService mock to return validation error message
         when(messageService.getMessage(anyString())).thenReturn("Validation error");
 
         sampleProject =
@@ -83,41 +77,6 @@ class SearchControllerTest {
                         .build();
     }
 
-    private SearchPage<ProjectDocument> createSearchPage(List<ProjectDocument> documents) {
-        List<SearchHit<ProjectDocument>> searchHits =
-                documents.stream()
-                        .map(
-                                doc ->
-                                        new SearchHit<>(
-                                                null,
-                                                doc.getId(),
-                                                null,
-                                                1.0f,
-                                                null,
-                                                null,
-                                                null,
-                                                null,
-                                                null,
-                                                null,
-                                                doc))
-                        .toList();
-
-        SearchHits<ProjectDocument> hits =
-                new SearchHitsImpl<>(
-                        documents.size(),
-                        TotalHitsRelation.EQUAL_TO,
-                        1.0f,
-                        null,
-                        null,
-                        null,
-                        searchHits,
-                        null,
-                        null,
-                        null);
-
-        return SearchHitSupport.searchPageFor(hits, PageRequest.of(0, 10));
-    }
-
     @Nested
     @DisplayName("GET /api/v1/search/projects")
     class SearchProjectsTests {
@@ -126,9 +85,10 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should return projects when search is successful")
         void shouldReturnProjectsWhenSearchIsSuccessful() throws Exception {
-            SearchPage<ProjectDocument> searchPage = createSearchPage(List.of(sampleProject));
-            when(searchService.advancedSearch(eq("java"), isNull(), isNull(), any()))
-                    .thenReturn(searchPage);
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    List.of(sampleProject), "Projects retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "java"))
                     .andExpect(status().isOk())
@@ -137,16 +97,17 @@ class SearchControllerTest {
                     .andExpect(jsonPath("$.data").isArray())
                     .andExpect(jsonPath("$.data[0].title").value("Java Spring Boot Project"));
 
-            verify(searchService).advancedSearch(eq("java"), isNull(), isNull(), any());
+            verify(mediator).send(any(SearchProjectsQuery.class));
         }
 
         @Test
         @WithMockUser
         @DisplayName("Should return empty list when no projects match")
         void shouldReturnEmptyListWhenNoProjectsMatch() throws Exception {
-            SearchPage<ProjectDocument> emptyPage = createSearchPage(Collections.emptyList());
-            when(searchService.advancedSearch(eq("nonexistent"), isNull(), isNull(), any()))
-                    .thenReturn(emptyPage);
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    Collections.emptyList(), "Projects retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "nonexistent"))
                     .andExpect(status().isOk())
@@ -162,11 +123,12 @@ class SearchControllerTest {
 
         @Test
         @WithMockUser
-        @DisplayName("Should filter by status when provided")
-        void shouldFilterByStatusWhenProvided() throws Exception {
-            SearchPage<ProjectDocument> searchPage = createSearchPage(List.of(sampleProject));
-            when(searchService.advancedSearch(eq("java"), eq("ACTIVE"), isNull(), any()))
-                    .thenReturn(searchPage);
+        @DisplayName("Should pass correct parameters to mediator")
+        void shouldPassCorrectParametersToMediator() throws Exception {
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    List.of(sampleProject), "Projects retrieved successfully"));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
@@ -175,16 +137,22 @@ class SearchControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data[0].status").value("ACTIVE"));
 
-            verify(searchService).advancedSearch(eq("java"), eq("ACTIVE"), isNull(), any());
+            ArgumentCaptor<SearchProjectsQuery> captor =
+                    ArgumentCaptor.forClass(SearchProjectsQuery.class);
+            verify(mediator).send(captor.capture());
+            SearchProjectsQuery captured = captor.getValue();
+            assert captured.q().equals("java");
+            assert captured.status().equals("ACTIVE");
         }
 
         @Test
         @WithMockUser
         @DisplayName("Should filter by tags when provided")
         void shouldFilterByTagsWhenProvided() throws Exception {
-            SearchPage<ProjectDocument> searchPage = createSearchPage(List.of(sampleProject));
-            when(searchService.advancedSearch(eq("java"), isNull(), eq(List.of("spring")), any()))
-                    .thenReturn(searchPage);
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    List.of(sampleProject), "Projects retrieved successfully"));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
@@ -193,17 +161,20 @@ class SearchControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data").isArray());
 
-            verify(searchService)
-                    .advancedSearch(eq("java"), isNull(), eq(List.of("spring")), any());
+            ArgumentCaptor<SearchProjectsQuery> captor =
+                    ArgumentCaptor.forClass(SearchProjectsQuery.class);
+            verify(mediator).send(captor.capture());
+            assert captor.getValue().tags().contains("spring");
         }
 
         @Test
         @WithMockUser
         @DisplayName("Should use pagination parameters")
         void shouldUsePaginationParameters() throws Exception {
-            SearchPage<ProjectDocument> searchPage = createSearchPage(List.of(sampleProject));
-            when(searchService.advancedSearch(anyString(), any(), any(), any()))
-                    .thenReturn(searchPage);
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    List.of(sampleProject), "Projects retrieved successfully"));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
@@ -212,15 +183,11 @@ class SearchControllerTest {
                                     .param("size", "20"))
                     .andExpect(status().isOk());
 
-            verify(searchService)
-                    .advancedSearch(
-                            eq("java"),
-                            isNull(),
-                            isNull(),
-                            argThat(
-                                    pageable ->
-                                            pageable.getPageNumber() == 2
-                                                    && pageable.getPageSize() == 20));
+            ArgumentCaptor<SearchProjectsQuery> captor =
+                    ArgumentCaptor.forClass(SearchProjectsQuery.class);
+            verify(mediator).send(captor.capture());
+            assert captor.getValue().page() == 2;
+            assert captor.getValue().size() == 20;
         }
     }
 
@@ -232,6 +199,9 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should return bad request when query is blank")
         void shouldReturnBadRequestWhenQueryIsBlank() throws Exception {
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenThrow(new ValidationException("q: must not be blank"));
+
             mockMvc.perform(get("/api/v1/search/projects").param("q", ""))
                     .andExpect(status().isBadRequest());
         }
@@ -247,7 +217,9 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should return bad request when query is too short")
         void shouldReturnBadRequestWhenQueryIsTooShort() throws Exception {
-            // @Size(min = 2) for projects search
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenThrow(new ValidationException("q: size must be between 2 and 100"));
+
             mockMvc.perform(get("/api/v1/search/projects").param("q", "a"))
                     .andExpect(status().isBadRequest());
         }
@@ -257,6 +229,9 @@ class SearchControllerTest {
         @DisplayName("Should return bad request when query exceeds max length")
         void shouldReturnBadRequestWhenQueryExceedsMaxLength() throws Exception {
             String longQuery = "a".repeat(101);
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenThrow(new ValidationException("q: size must be between 2 and 100"));
+
             mockMvc.perform(get("/api/v1/search/projects").param("q", longQuery))
                     .andExpect(status().isBadRequest());
         }
@@ -265,6 +240,9 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should return bad request when page is negative")
         void shouldReturnBadRequestWhenPageIsNegative() throws Exception {
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenThrow(new ValidationException("page: must be greater than or equal to 0"));
+
             mockMvc.perform(get("/api/v1/search/projects").param("q", "java").param("page", "-1"))
                     .andExpect(status().isBadRequest());
         }
@@ -273,6 +251,9 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should return bad request when size is zero")
         void shouldReturnBadRequestWhenSizeIsZero() throws Exception {
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenThrow(new ValidationException("size: must be greater than or equal to 1"));
+
             mockMvc.perform(get("/api/v1/search/projects").param("q", "java").param("size", "0"))
                     .andExpect(status().isBadRequest());
         }
@@ -281,12 +262,16 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should return bad request when size exceeds maximum")
         void shouldReturnBadRequestWhenSizeExceedsMaximum() throws Exception {
+            when(mediator.send(any(SearchProjectsQuery.class)))
+                    .thenThrow(
+                            new ValidationException(
+                                    "size: must be less than or equal to 100"));
+
             mockMvc.perform(get("/api/v1/search/projects").param("q", "java").param("size", "101"))
                     .andExpect(status().isBadRequest());
         }
 
         @Test
-        // REMOVED @WithMockUser to ensure true unauthorized response
         @DisplayName("Should return unauthorized when user is not authenticated")
         void shouldReturnUnauthorizedWhenUserIsNotAuthenticated() throws Exception {
             mockMvc.perform(get("/api/v1/search/projects").param("q", "java"))
@@ -304,7 +289,9 @@ class SearchControllerTest {
         void shouldReturnSuggestionsWhenQueryIsValid() throws Exception {
             List<String> suggestions =
                     List.of("Java Spring Boot Project", "Java Backend Application");
-            when(searchService.getSuggestions("java")).thenReturn(suggestions);
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(suggestions, "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "java"))
                     .andExpect(status().isOk())
@@ -314,14 +301,18 @@ class SearchControllerTest {
                     .andExpect(jsonPath("$.data[0]").value("Java Spring Boot Project"))
                     .andExpect(jsonPath("$.data[1]").value("Java Backend Application"));
 
-            verify(searchService).getSuggestions("java");
+            verify(mediator).send(any(SuggestProjectsQuery.class));
         }
 
         @Test
         @WithMockUser
         @DisplayName("Should return empty list when no suggestions found")
         void shouldReturnEmptyListWhenNoSuggestionsFound() throws Exception {
-            when(searchService.getSuggestions("xyz")).thenReturn(Collections.emptyList());
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    Collections.emptyList(),
+                                    "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "xyz"))
                     .andExpect(status().isOk())
@@ -333,8 +324,11 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should accept single character query")
         void shouldAcceptSingleCharacterQuery() throws Exception {
-            // @Size(min = 1) for suggestions
-            when(searchService.getSuggestions("j")).thenReturn(List.of("Java Project"));
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    List.of("Java Project"),
+                                    "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "j"))
                     .andExpect(status().isOk())
@@ -345,6 +339,9 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should return bad request when query is blank")
         void shouldReturnBadRequestWhenQueryIsBlank() throws Exception {
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenThrow(new ValidationException("q: must not be blank"));
+
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", ""))
                     .andExpect(status().isBadRequest());
         }
@@ -362,12 +359,14 @@ class SearchControllerTest {
         @DisplayName("Should return bad request when query exceeds max length")
         void shouldReturnBadRequestWhenQueryExceedsMaxLength() throws Exception {
             String longQuery = "a".repeat(101);
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenThrow(new ValidationException("q: size must be between 1 and 100"));
+
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", longQuery))
                     .andExpect(status().isBadRequest());
         }
 
         @Test
-        // REMOVED @WithMockUser to ensure true unauthorized response
         @DisplayName("Should return unauthorized when user is not authenticated")
         void shouldReturnUnauthorizedWhenUserIsNotAuthenticated() throws Exception {
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "java"))
@@ -384,7 +383,9 @@ class SearchControllerTest {
         @DisplayName("Should return statistics successfully")
         void shouldReturnStatisticsSuccessfully() throws Exception {
             Map<String, Long> stats = Map.of("ACTIVE", 10L, "COMPLETED", 5L, "DRAFT", 3L);
-            when(searchService.getProjectStatistics()).thenReturn(stats);
+            when(mediator.send(any(GetProjectStatisticsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(stats, "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())
@@ -394,14 +395,18 @@ class SearchControllerTest {
                     .andExpect(jsonPath("$.data.COMPLETED").value(5))
                     .andExpect(jsonPath("$.data.DRAFT").value(3));
 
-            verify(searchService).getProjectStatistics();
+            verify(mediator).send(any(GetProjectStatisticsQuery.class));
         }
 
         @Test
         @WithMockUser
         @DisplayName("Should return empty statistics when no data")
         void shouldReturnEmptyStatisticsWhenNoData() throws Exception {
-            when(searchService.getProjectStatistics()).thenReturn(Collections.emptyMap());
+            when(mediator.send(any(GetProjectStatisticsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    Collections.emptyMap(),
+                                    "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())
@@ -410,7 +415,6 @@ class SearchControllerTest {
         }
 
         @Test
-        // REMOVED @WithMockUser to ensure true unauthorized response
         @DisplayName("Should return unauthorized when user is not authenticated")
         void shouldReturnUnauthorizedWhenUserIsNotAuthenticated() throws Exception {
             mockMvc.perform(get("/api/v1/search/projects/statistics"))

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
@@ -3,8 +3,6 @@ package com.iyte_yazilim.proje_pazari.presentation.mappers;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.presentation.security.UserPrincipal;
 import java.util.HashMap;
@@ -38,9 +36,7 @@ class AutoRequestMapperTest {
 
     @BeforeEach
     void setUp() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        mapper = new AutoRequestMapper(objectMapper);
+        mapper = new AutoRequestMapper();
     }
 
     private Authentication mockAuth(String userId) {

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
@@ -105,8 +105,7 @@ class AutoRequestMapperTest {
             RequesterCommand body = new RequesterCommand("ignored", "doSomething");
             Authentication auth = mockAuth("requester-789");
 
-            RequesterCommand result =
-                    mapper.map(RequesterCommand.class, null, null, body, auth);
+            RequesterCommand result = mapper.map(RequesterCommand.class, null, null, body, auth);
 
             assertEquals("requester-789", result.requesterId());
             assertEquals("doSomething", result.action());
@@ -152,8 +151,7 @@ class AutoRequestMapperTest {
         void shouldMapPathVariables() {
             Map<String, String> pathVars = Map.of("name", "Bob");
 
-            SimpleCommand result =
-                    mapper.map(SimpleCommand.class, pathVars, null, null, null);
+            SimpleCommand result = mapper.map(SimpleCommand.class, pathVars, null, null, null);
 
             assertEquals("Bob", result.name());
         }
@@ -164,8 +162,7 @@ class AutoRequestMapperTest {
             SimpleCommand body = new SimpleCommand("BodyName", 20);
             Map<String, String> pathVars = Map.of("name", "PathName");
 
-            SimpleCommand result =
-                    mapper.map(SimpleCommand.class, pathVars, null, body, null);
+            SimpleCommand result = mapper.map(SimpleCommand.class, pathVars, null, body, null);
 
             assertEquals("PathName", result.name());
             assertEquals(20, result.age());
@@ -198,12 +195,7 @@ class AutoRequestMapperTest {
 
             FileUploadCommand result =
                     mapper.map(
-                            FileUploadCommand.class,
-                            null,
-                            null,
-                            null,
-                            auth,
-                            Map.of("file", file));
+                            FileUploadCommand.class, null, null, null, auth, Map.of("file", file));
 
             assertEquals("user-123", result.userId());
             assertNotNull(result.file());
@@ -256,7 +248,8 @@ class AutoRequestMapperTest {
     class MergePriority {
 
         @Test
-        @DisplayName("should follow merge priority: body < queryParams < pathVars < auth < extraFields")
+        @DisplayName(
+                "should follow merge priority: body < queryParams < pathVars < auth < extraFields")
         void shouldFollowMergePriority() {
             UserIdCommand body = new UserIdCommand("body-user", "body-name");
             Map<String, String> queryParams = new HashMap<>();
@@ -279,8 +272,7 @@ class AutoRequestMapperTest {
             Map<String, Object> extraFields = Map.of("userId", "extra-user");
 
             UserIdCommand result =
-                    mapper.map(
-                            UserIdCommand.class, null, null, body, auth, extraFields);
+                    mapper.map(UserIdCommand.class, null, null, body, auth, extraFields);
 
             assertEquals("extra-user", result.userId());
         }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
@@ -1,0 +1,292 @@
+package com.iyte_yazilim.proje_pazari.presentation.mappers;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.presentation.security.UserPrincipal;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.multipart.MultipartFile;
+
+class AutoRequestMapperTest {
+
+    private AutoRequestMapper mapper;
+
+    public record SimpleCommand(String name, int age) implements IRequest<Void> {}
+
+    public record UserIdCommand(String userId, String name) implements IRequest<Void> {}
+
+    public record OwnerIdCommand(String ownerId, String title) implements IRequest<Void> {}
+
+    public record MultiFieldAuthCommand(String userId, String ownerId, String data)
+            implements IRequest<Void> {}
+
+    public record FileUploadCommand(String userId, MultipartFile file) implements IRequest<Void> {}
+
+    public record EmptyCommand() implements IRequest<Void> {}
+
+    public record RequesterCommand(String requesterId, String action) implements IRequest<Void> {}
+
+    @BeforeEach
+    void setUp() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        mapper = new AutoRequestMapper(objectMapper);
+    }
+
+    private Authentication mockAuth(String userId) {
+        Authentication auth = mock(Authentication.class);
+        UserPrincipal principal = new UserPrincipal(userId, "test@example.com", "USER");
+        when(auth.getPrincipal()).thenReturn(principal);
+        return auth;
+    }
+
+    @Nested
+    @DisplayName("Body-only mapping")
+    class BodyOnlyMapping {
+
+        @Test
+        @DisplayName("should map body fields to record")
+        void shouldMapBodyFieldsToRecord() {
+            SimpleCommand body = new SimpleCommand("Alice", 25);
+
+            SimpleCommand result = mapper.map(SimpleCommand.class, null, null, body, null);
+
+            assertEquals("Alice", result.name());
+            assertEquals(25, result.age());
+        }
+
+        @Test
+        @DisplayName("should handle null body")
+        void shouldHandleNullBody() {
+            SimpleCommand result = mapper.map(SimpleCommand.class, null, null, null, null);
+
+            assertNull(result.name());
+            assertEquals(0, result.age());
+        }
+    }
+
+    @Nested
+    @DisplayName("Authentication injection")
+    class AuthInjection {
+
+        @Test
+        @DisplayName("should inject userId from auth")
+        void shouldInjectUserIdFromAuth() {
+            UserIdCommand body = new UserIdCommand("ignored", "Alice");
+            Authentication auth = mockAuth("auth-user-123");
+
+            UserIdCommand result = mapper.map(UserIdCommand.class, null, null, body, auth);
+
+            assertEquals("auth-user-123", result.userId());
+            assertEquals("Alice", result.name());
+        }
+
+        @Test
+        @DisplayName("should inject ownerId from auth")
+        void shouldInjectOwnerIdFromAuth() {
+            OwnerIdCommand body = new OwnerIdCommand("malicious-id", "Project X");
+            Authentication auth = mockAuth("real-owner-456");
+
+            OwnerIdCommand result = mapper.map(OwnerIdCommand.class, null, null, body, auth);
+
+            assertEquals("real-owner-456", result.ownerId());
+            assertEquals("Project X", result.title());
+        }
+
+        @Test
+        @DisplayName("should inject requesterId from auth")
+        void shouldInjectRequesterIdFromAuth() {
+            RequesterCommand body = new RequesterCommand("ignored", "doSomething");
+            Authentication auth = mockAuth("requester-789");
+
+            RequesterCommand result =
+                    mapper.map(RequesterCommand.class, null, null, body, auth);
+
+            assertEquals("requester-789", result.requesterId());
+            assertEquals("doSomething", result.action());
+        }
+
+        @Test
+        @DisplayName("should inject all auth-eligible fields")
+        void shouldInjectAllAuthEligibleFields() {
+            MultiFieldAuthCommand body = new MultiFieldAuthCommand("bad1", "bad2", "keepme");
+            Authentication auth = mockAuth("secure-user");
+
+            MultiFieldAuthCommand result =
+                    mapper.map(MultiFieldAuthCommand.class, null, null, body, auth);
+
+            assertEquals("secure-user", result.userId());
+            assertEquals("secure-user", result.ownerId());
+            assertEquals("keepme", result.data());
+        }
+    }
+
+    @Nested
+    @DisplayName("Malicious override prevention")
+    class MaliciousOverridePrevention {
+
+        @Test
+        @DisplayName("should override malicious userId from body with auth userId")
+        void shouldOverrideMaliciousUserId() {
+            UserIdCommand body = new UserIdCommand("attacker-id", "Evil");
+            Authentication auth = mockAuth("real-user-id");
+
+            UserIdCommand result = mapper.map(UserIdCommand.class, null, null, body, auth);
+
+            assertEquals("real-user-id", result.userId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Path variable mapping")
+    class PathVariableMapping {
+
+        @Test
+        @DisplayName("should map path variables to record fields")
+        void shouldMapPathVariables() {
+            Map<String, String> pathVars = Map.of("name", "Bob");
+
+            SimpleCommand result =
+                    mapper.map(SimpleCommand.class, pathVars, null, null, null);
+
+            assertEquals("Bob", result.name());
+        }
+
+        @Test
+        @DisplayName("path variables should override body")
+        void pathVariablesShouldOverrideBody() {
+            SimpleCommand body = new SimpleCommand("BodyName", 20);
+            Map<String, String> pathVars = Map.of("name", "PathName");
+
+            SimpleCommand result =
+                    mapper.map(SimpleCommand.class, pathVars, null, body, null);
+
+            assertEquals("PathName", result.name());
+            assertEquals(20, result.age());
+        }
+
+        @Test
+        @DisplayName("query params should override body but not path vars")
+        void queryParamsShouldOverrideBody() {
+            SimpleCommand body = new SimpleCommand("BodyName", 20);
+            Map<String, String> queryParams = Map.of("name", "QueryName");
+            Map<String, String> pathVars = Map.of("name", "PathName");
+
+            SimpleCommand result =
+                    mapper.map(SimpleCommand.class, pathVars, queryParams, body, null);
+
+            assertEquals("PathName", result.name());
+        }
+    }
+
+    @Nested
+    @DisplayName("MultipartFile handling")
+    class MultipartFileHandling {
+
+        @Test
+        @DisplayName("should handle MultipartFile via constructor")
+        void shouldHandleMultipartFile() {
+            MockMultipartFile file =
+                    new MockMultipartFile("file", "test.jpg", "image/jpeg", "data".getBytes());
+            Authentication auth = mockAuth("user-123");
+
+            FileUploadCommand result =
+                    mapper.map(
+                            FileUploadCommand.class,
+                            null,
+                            null,
+                            null,
+                            auth,
+                            Map.of("file", file));
+
+            assertEquals("user-123", result.userId());
+            assertNotNull(result.file());
+            assertEquals("test.jpg", result.file().getOriginalFilename());
+        }
+    }
+
+    @Nested
+    @DisplayName("Empty records")
+    class EmptyRecords {
+
+        @Test
+        @DisplayName("should handle empty record with no fields")
+        void shouldHandleEmptyRecord() {
+            EmptyCommand result = mapper.map(EmptyCommand.class, null, null, null, null);
+
+            assertNotNull(result);
+        }
+    }
+
+    @Nested
+    @DisplayName("Null auth safety")
+    class NullAuthSafety {
+
+        @Test
+        @DisplayName("should not inject auth fields when auth is null")
+        void shouldNotInjectWhenAuthIsNull() {
+            UserIdCommand body = new UserIdCommand("original-id", "Alice");
+
+            UserIdCommand result = mapper.map(UserIdCommand.class, null, null, body, null);
+
+            assertEquals("original-id", result.userId());
+        }
+
+        @Test
+        @DisplayName("should not inject when principal is not UserPrincipal")
+        void shouldNotInjectWhenPrincipalIsNotUserPrincipal() {
+            UserIdCommand body = new UserIdCommand("original-id", "Alice");
+            Authentication auth = mock(Authentication.class);
+            when(auth.getPrincipal()).thenReturn("some-string-principal");
+
+            UserIdCommand result = mapper.map(UserIdCommand.class, null, null, body, auth);
+
+            assertEquals("original-id", result.userId());
+        }
+    }
+
+    @Nested
+    @DisplayName("Merge priority")
+    class MergePriority {
+
+        @Test
+        @DisplayName("should follow merge priority: body < queryParams < pathVars < auth < extraFields")
+        void shouldFollowMergePriority() {
+            UserIdCommand body = new UserIdCommand("body-user", "body-name");
+            Map<String, String> queryParams = new HashMap<>();
+            queryParams.put("name", "query-name");
+            Map<String, String> pathVars = new HashMap<>();
+            Authentication auth = mockAuth("auth-user");
+
+            UserIdCommand result =
+                    mapper.map(UserIdCommand.class, pathVars, queryParams, body, auth);
+
+            assertEquals("auth-user", result.userId());
+            assertEquals("query-name", result.name());
+        }
+
+        @Test
+        @DisplayName("extraFields should have highest priority")
+        void extraFieldsShouldHaveHighestPriority() {
+            UserIdCommand body = new UserIdCommand("body-user", "body-name");
+            Authentication auth = mockAuth("auth-user");
+            Map<String, Object> extraFields = Map.of("userId", "extra-user");
+
+            UserIdCommand result =
+                    mapper.map(
+                            UserIdCommand.class, null, null, body, auth, extraFields);
+
+            assertEquals("extra-user", result.userId());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Centralized `ResponseCode` → `HttpStatus` mapping and `IMediator.send()` into `BaseController`, removing duplicated switch expressions from all controllers
- Added `IRequestMapper` / `AutoRequestMapper` for reflective request object construction from path variables, query params, request body, and auth context
- Extracted Elasticsearch admin operations (`reindex`, `deleteAllIndexes`) and search/suggest/download/statistics queries into proper CQRS command/query objects with handlers

## Test plan
- [ ] Verify all existing controller tests pass (`./gradlew test`)
- [ ] Verify `AutoRequestMapperTest` covers mapping from path vars, query params, body, and auth
- [ ] Verify `SearchControllerTest` and `AdminControllerTest` work with the new `BaseController.send()` flow
- [ ] Manual smoke test: hit `/api/v1/users`, `/api/v1/projects`, `/api/v1/search` endpoints and confirm correct HTTP status codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)