### PR TITLE
Refactor: Enforce Thin Controllers and CQRS Architecture

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importProjectsFromCsv/ImportProjectsFromCsvCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importProjectsFromCsv/ImportProjectsFromCsvCommand.java
@@ -3,6 +3,11 @@ package com.iyte_yazilim.proje_pazari.application.commands.importProjectsFromCsv
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.application.dtos.ImportResultDTO;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import org.springframework.web.multipart.MultipartFile;
 
-public record ImportProjectsFromCsvCommand(String csvContent)
-        implements IRequest<ApiResponse<ImportResultDTO>> {}
+public record ImportProjectsFromCsvCommand(String csvContent, MultipartFile file)
+        implements IRequest<ApiResponse<ImportResultDTO>> {
+    public ImportProjectsFromCsvCommand(String csvContent) {
+        this(csvContent, null);
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importProjectsFromCsv/ImportProjectsFromCsvHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importProjectsFromCsv/ImportProjectsFromCsvHandler.java
@@ -9,7 +9,9 @@ import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +33,14 @@ public class ImportProjectsFromCsvHandler
     @Override
     @Transactional
     public ApiResponse<ImportResultDTO> handle(ImportProjectsFromCsvCommand command) {
-        if (command.csvContent() == null || command.csvContent().isBlank()) {
+        String csvContent;
+        try {
+            csvContent = resolveCsvContent(command);
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.validationError(e.getMessage());
+        }
+
+        if (csvContent == null || csvContent.isBlank()) {
             return ApiResponse.validationError("CSV content is empty");
         }
 
@@ -39,7 +48,7 @@ public class ImportProjectsFromCsvHandler
         int totalRows = 0;
         int successCount = 0;
 
-        try (BufferedReader reader = new BufferedReader(new StringReader(command.csvContent()))) {
+        try (BufferedReader reader = new BufferedReader(new StringReader(csvContent))) {
             String headerLine = reader.readLine();
             if (headerLine == null) {
                 return ApiResponse.validationError("CSV file is empty");
@@ -133,5 +142,21 @@ public class ImportProjectsFromCsvHandler
         ImportResultDTO result = new ImportResultDTO(totalRows, successCount, failedCount, errors);
         return ApiResponse.success(
                 result, "Import completed: " + successCount + " projects imported");
+    }
+
+    private String resolveCsvContent(ImportProjectsFromCsvCommand command) {
+        if (command.csvContent() != null && !command.csvContent().isBlank()) {
+            return command.csvContent();
+        }
+
+        if (command.file() == null || command.file().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return new String(command.file().getBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to read file: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importUsersFromCsv/ImportUsersFromCsvCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importUsersFromCsv/ImportUsersFromCsvCommand.java
@@ -3,6 +3,11 @@ package com.iyte_yazilim.proje_pazari.application.commands.importUsersFromCsv;
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.application.dtos.ImportResultDTO;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import org.springframework.web.multipart.MultipartFile;
 
-public record ImportUsersFromCsvCommand(String csvContent)
-        implements IRequest<ApiResponse<ImportResultDTO>> {}
+public record ImportUsersFromCsvCommand(String csvContent, MultipartFile file)
+        implements IRequest<ApiResponse<ImportResultDTO>> {
+    public ImportUsersFromCsvCommand(String csvContent) {
+        this(csvContent, null);
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importUsersFromCsv/ImportUsersFromCsvHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/importUsersFromCsv/ImportUsersFromCsvHandler.java
@@ -7,7 +7,9 @@ import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -28,7 +30,14 @@ public class ImportUsersFromCsvHandler
     @Override
     @Transactional
     public ApiResponse<ImportResultDTO> handle(ImportUsersFromCsvCommand command) {
-        if (command.csvContent() == null || command.csvContent().isBlank()) {
+        String csvContent;
+        try {
+            csvContent = resolveCsvContent(command);
+        } catch (IllegalArgumentException e) {
+            return ApiResponse.validationError(e.getMessage());
+        }
+
+        if (csvContent == null || csvContent.isBlank()) {
             return ApiResponse.validationError("CSV content is empty");
         }
 
@@ -36,7 +45,7 @@ public class ImportUsersFromCsvHandler
         int totalRows = 0;
         int successCount = 0;
 
-        try (BufferedReader reader = new BufferedReader(new StringReader(command.csvContent()))) {
+        try (BufferedReader reader = new BufferedReader(new StringReader(csvContent))) {
             String headerLine = reader.readLine();
             if (headerLine == null) {
                 return ApiResponse.validationError("CSV file is empty");
@@ -106,5 +115,21 @@ public class ImportUsersFromCsvHandler
         int failedCount = totalRows - successCount;
         ImportResultDTO result = new ImportResultDTO(totalRows, successCount, failedCount, errors);
         return ApiResponse.success(result, "Import completed: " + successCount + " users imported");
+    }
+
+    private String resolveCsvContent(ImportUsersFromCsvCommand command) {
+        if (command.csvContent() != null && !command.csvContent().isBlank()) {
+            return command.csvContent();
+        }
+
+        if (command.file() == null || command.file().isEmpty()) {
+            return null;
+        }
+
+        try {
+            return new String(command.file().getBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Failed to read file: " + e.getMessage(), e);
+        }
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenCommand.java
@@ -1,0 +1,7 @@
+package com.iyte_yazilim.proje_pazari.application.commands.refreshToken;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+
+public record RefreshTokenCommand(String refreshToken)
+        implements IRequest<ApiResponse<RefreshTokenResult>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenHandler.java
@@ -1,0 +1,52 @@
+package com.iyte_yazilim.proje_pazari.application.commands.refreshToken;
+
+import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.security.service.RefreshTokenService;
+import com.iyte_yazilim.proje_pazari.presentation.security.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenHandler
+        implements IRequestHandler<RefreshTokenCommand, ApiResponse<RefreshTokenResult>> {
+
+    private final RefreshTokenService refreshTokenService;
+    private final UserRepository userRepository;
+    private final JwtUtil jwtUtil;
+    private final MessageService messageService;
+
+    @Override
+    public ApiResponse<RefreshTokenResult> handle(RefreshTokenCommand command) {
+        String refreshToken = command.refreshToken();
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new ValidationException("Refresh token is required");
+        }
+
+        var userIdOpt = refreshTokenService.validateRefreshToken(refreshToken);
+        if (userIdOpt.isEmpty()) {
+            throw new ValidationException("Invalid or expired refresh token");
+        }
+
+        String userId = userIdOpt.get();
+        UserEntity user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException(userId));
+
+        refreshTokenService.revokeRefreshToken(refreshToken);
+        String newRefreshToken = refreshTokenService.createRefreshToken(userId);
+        String role = user.getRole() != null ? user.getRole().toString() : "APPLICANT";
+        String newAccessToken = jwtUtil.generateToken(user.getId(), user.getEmail(), role);
+
+        var result =
+                new RefreshTokenResult(
+                        user.getId(), user.getEmail(), role, newAccessToken, newRefreshToken);
+
+        return ApiResponse.success(result, messageService.getMessage("auth.token.refreshed"));
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenHandler.java
@@ -1,8 +1,8 @@
 package com.iyte_yazilim.proje_pazari.application.commands.refreshToken;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -35,8 +35,10 @@ public class RefreshTokenHandler
         }
 
         String userId = userIdOpt.get();
-        UserEntity user = userRepository.findById(userId)
-                .orElseThrow(() -> new UserNotFoundException(userId));
+        UserEntity user =
+                userRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new UserNotFoundException(userId));
 
         refreshTokenService.revokeRefreshToken(refreshToken);
         String newRefreshToken = refreshTokenService.createRefreshToken(userId);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenResult.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/refreshToken/RefreshTokenResult.java
@@ -1,0 +1,4 @@
+package com.iyte_yazilim.proje_pazari.application.commands.refreshToken;
+
+public record RefreshTokenResult(
+        String userId, String email, String role, String accessToken, String refreshToken) {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileCommand.java
@@ -3,8 +3,8 @@ package com.iyte_yazilim.proje_pazari.application.commands.uploadFile;
 import com.iyte_yazilim.proje_pazari.application.common.ICommand;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Map;
 import jakarta.validation.constraints.NotNull;
+import java.util.Map;
 import org.springframework.web.multipart.MultipartFile;
 
 @Schema(description = "Command to upload a generic file")

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileCommand.java
@@ -1,0 +1,15 @@
+package com.iyte_yazilim.proje_pazari.application.commands.uploadFile;
+
+import com.iyte_yazilim.proje_pazari.application.common.ICommand;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Map;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
+
+@Schema(description = "Command to upload a generic file")
+public record UploadFileCommand(
+        @Schema(description = "File to upload", requiredMode = Schema.RequiredMode.REQUIRED)
+                @NotNull(message = "File is required")
+                MultipartFile file)
+        implements ICommand<ApiResponse<Map<String, Object>>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandler.java
@@ -1,0 +1,45 @@
+package com.iyte_yazilim.proje_pazari.application.commands.uploadFile;
+
+import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class UploadFileHandler
+        implements IRequestHandler<UploadFileCommand, ApiResponse<Map<String, Object>>> {
+
+    private static final String DEFAULT_DIRECTORY = "uploads";
+    private final FileStorageService fileStorageService;
+
+    @Override
+    public ApiResponse<Map<String, Object>> handle(UploadFileCommand command) {
+        if (command.file() == null || command.file().isEmpty()) {
+            return ApiResponse.badRequest("File is empty");
+        }
+
+        String filename = command.file().getOriginalFilename();
+        if (filename == null || filename.isBlank() || filename.contains("..")) {
+            return ApiResponse.badRequest("Invalid filename");
+        }
+
+        try {
+            String filePath = fileStorageService.storeFile(command.file(), DEFAULT_DIRECTORY);
+            Map<String, Object> fileData =
+                    Map.of(
+                            "filename", filename,
+                            "url", "/api/v1/files/" + filePath,
+                            "size", command.file().getSize());
+            return ApiResponse.success(fileData, "File uploaded successfully");
+        } catch (FileStorageException e) {
+            log.error("File upload failed: {}", e.getMessage());
+            return ApiResponse.error("File upload failed: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandler.java
@@ -33,9 +33,12 @@ public class UploadFileHandler
             String filePath = fileStorageService.storeFile(command.file(), DEFAULT_DIRECTORY);
             Map<String, Object> fileData =
                     Map.of(
-                            "filename", filename,
-                            "url", "/api/v1/files/" + filePath,
-                            "size", command.file().getSize());
+                            "filename",
+                            filename,
+                            "url",
+                            "/api/v1/files/" + filePath,
+                            "size",
+                            command.file().getSize());
             return ApiResponse.success(fileData, "File uploaded successfully");
         } catch (FileStorageException e) {
             log.error("File upload failed: {}", e.getMessage());

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsHandler.java
@@ -1,0 +1,26 @@
+package com.iyte_yazilim.proje_pazari.application.queries.getAllProjects;
+
+import com.iyte_yazilim.proje_pazari.domain.entities.Project;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers.ProjectMapper;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetAllProjectsHandler
+        implements IRequestHandler<GetAllProjectsQuery, ApiResponse<List<Project>>> {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectMapper projectMapper;
+
+    @Override
+    public ApiResponse<List<Project>> handle(GetAllProjectsQuery query) {
+        List<Project> projects =
+                projectRepository.findAll().stream().map(projectMapper::entityToDomain).toList();
+        return ApiResponse.success(projects, "Projects retrieved successfully");
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQuery.java
@@ -1,0 +1,8 @@
+package com.iyte_yazilim.proje_pazari.application.queries.getAllProjects;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.entities.Project;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import java.util.List;
+
+public record GetAllProjectsQuery() implements IRequest<ApiResponse<List<Project>>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectById/GetProjectByIdHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectById/GetProjectByIdHandler.java
@@ -1,0 +1,27 @@
+package com.iyte_yazilim.proje_pazari.application.queries.getProjectById;
+
+import com.iyte_yazilim.proje_pazari.domain.entities.Project;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers.ProjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class GetProjectByIdHandler
+        implements IRequestHandler<GetProjectByIdQuery, ApiResponse<Project>> {
+
+    private final ProjectRepository projectRepository;
+    private final ProjectMapper projectMapper;
+
+    @Override
+    public ApiResponse<Project> handle(GetProjectByIdQuery query) {
+        return projectRepository
+                .findById(query.projectId())
+                .map(projectMapper::entityToDomain)
+                .map(project -> ApiResponse.success(project, "Project retrieved successfully"))
+                .orElseGet(() -> ApiResponse.notFound("Project not found"));
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectById/GetProjectByIdQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectById/GetProjectByIdQuery.java
@@ -1,0 +1,7 @@
+package com.iyte_yazilim.proje_pazari.application.queries.getProjectById;
+
+import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.entities.Project;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+
+public record GetProjectByIdQuery(String projectId) implements IRequest<ApiResponse<Project>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -116,6 +116,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
+    @ExceptionHandler(com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDomainValidationException(
+            com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException ex) {
+        log.error("Validation error: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.validationError(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
     @ExceptionHandler(FileStorageException.class)
     public ResponseEntity<ApiResponse<Void>> handleFileStorageException(FileStorageException ex) {
         log.debug("File storage error: {}", ex.getMessage());

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
@@ -513,14 +513,7 @@ public class AdminController extends BaseController {
             importUsers(
                     @org.springframework.web.bind.annotation.RequestPart("file")
                             org.springframework.web.multipart.MultipartFile file) {
-        try {
-            String csvContent =
-                    new String(file.getBytes(), java.nio.charset.StandardCharsets.UTF_8);
-            return send(new ImportUsersFromCsvCommand(csvContent));
-        } catch (java.io.IOException e) {
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.validationError("Failed to read file: " + e.getMessage()));
-        }
+        return send(ImportUsersFromCsvCommand.class, null, null, null, null, Map.of("file", file));
     }
 
     @PostMapping(value = "/import/projects", consumes = "multipart/form-data")
@@ -533,14 +526,13 @@ public class AdminController extends BaseController {
             importProjects(
                     @org.springframework.web.bind.annotation.RequestPart("file")
                             org.springframework.web.multipart.MultipartFile file) {
-        try {
-            String csvContent =
-                    new String(file.getBytes(), java.nio.charset.StandardCharsets.UTF_8);
-            return send(new ImportProjectsFromCsvCommand(csvContent));
-        } catch (java.io.IOException e) {
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.validationError("Failed to read file: " + e.getMessage()));
-        }
+        return send(
+                ImportProjectsFromCsvCommand.class,
+                null,
+                null,
+                null,
+                null,
+                Map.of("file", file));
     }
 
     // ==================== SCHEDULED EMAIL BROADCASTS ====================

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
@@ -53,6 +53,7 @@ import com.iyte_yazilim.proje_pazari.application.queries.exportApplications.Expo
 import com.iyte_yazilim.proje_pazari.application.queries.exportProjects.ExportProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.exportUsers.ExportUsersQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getActiveSessions.GetActiveSessionsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.getAnalyticsTrends.GetAnalyticsTrendsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getApplicationStats.GetApplicationStatsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getAuditLogs.GetAuditLogsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getFeatureFlags.GetFeatureFlagsQuery;
@@ -64,7 +65,6 @@ import com.iyte_yazilim.proje_pazari.application.queries.getSystemConfig.GetSyst
 import com.iyte_yazilim.proje_pazari.application.queries.getSystemHealth.GetSystemHealthQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getSystemOverview.GetSystemOverviewQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getUserStats.GetUserStatsQuery;
-import com.iyte_yazilim.proje_pazari.application.queries.getAnalyticsTrends.GetAnalyticsTrendsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.listBannedIps.ListBannedIpsQuery;
 import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
 import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
@@ -124,7 +124,14 @@ public class AdminController extends BaseController {
     @Audited(action = "ADMIN_UPDATE_USER", entityType = "USER")
     public ResponseEntity<ApiResponse<Void>> updateUser(
             @PathVariable String userId, @RequestBody UpdateUserRequest request) {
-        return send(new AdminUpdateUserCommand(userId, request.role(), request.isActive(), request.firstName(), request.lastName(), request.description()));
+        return send(
+                new AdminUpdateUserCommand(
+                        userId,
+                        request.role(),
+                        request.isActive(),
+                        request.firstName(),
+                        request.lastName(),
+                        request.description()));
     }
 
     @DeleteMapping("/users/{userId}")
@@ -267,8 +274,8 @@ public class AdminController extends BaseController {
             summary = "Analytics trends",
             description =
                     "Get time-series trend data for user growth, project creation, and application activity")
-    public ResponseEntity<ApiResponse<AnalyticsTrendsDTO>>
-            getAnalyticsTrends(@RequestParam(defaultValue = "30") int days) {
+    public ResponseEntity<ApiResponse<AnalyticsTrendsDTO>> getAnalyticsTrends(
+            @RequestParam(defaultValue = "30") int days) {
         return send(new GetAnalyticsTrendsQuery(days));
     }
 
@@ -319,7 +326,8 @@ public class AdminController extends BaseController {
     @Audited(action = "REVIEW_FLAGGED_CONTENT", entityType = "CONTENT")
     public ResponseEntity<ApiResponse<Void>> reviewFlaggedContent(
             @PathVariable String flagId, @RequestBody ReviewFlaggedContentRequest request) {
-        return send(new ReviewFlaggedContentCommand(flagId, request.action(), request.reviewNote()));
+        return send(
+                new ReviewFlaggedContentCommand(flagId, request.action(), request.reviewNote()));
     }
 
     // ==================== EMAIL & NOTIFICATIONS ====================
@@ -331,7 +339,8 @@ public class AdminController extends BaseController {
     @Audited(action = "BROADCAST_EMAIL", entityType = "EMAIL")
     public ResponseEntity<ApiResponse<Void>> broadcastEmail(
             @RequestBody BroadcastEmailRequest request) {
-        return send(new BroadcastEmailCommand(request.subject(), request.body(), request.targetRole()));
+        return send(
+                new BroadcastEmailCommand(request.subject(), request.body(), request.targetRole()));
     }
 
     @PostMapping("/email/targeted")
@@ -339,7 +348,8 @@ public class AdminController extends BaseController {
     @Audited(action = "TARGETED_EMAIL", entityType = "EMAIL")
     public ResponseEntity<ApiResponse<Void>> sendTargetedEmail(
             @RequestBody SendTargetedEmailRequest request) {
-        return send(new SendTargetedEmailCommand(request.userIds(), request.subject(), request.body()));
+        return send(
+                new SendTargetedEmailCommand(request.userIds(), request.subject(), request.body()));
     }
 
     // ==================== DATA EXPORT ====================
@@ -509,10 +519,9 @@ public class AdminController extends BaseController {
             description =
                     "Import users from a CSV file. Expected columns: email,firstName,lastName,role,password")
     @Audited(action = "IMPORT_USERS_CSV", entityType = "USER")
-    public ResponseEntity<ApiResponse<ImportResultDTO>>
-            importUsers(
-                    @org.springframework.web.bind.annotation.RequestPart("file")
-                            org.springframework.web.multipart.MultipartFile file) {
+    public ResponseEntity<ApiResponse<ImportResultDTO>> importUsers(
+            @org.springframework.web.bind.annotation.RequestPart("file")
+                    org.springframework.web.multipart.MultipartFile file) {
         return send(ImportUsersFromCsvCommand.class, null, null, null, null, Map.of("file", file));
     }
 
@@ -522,17 +531,11 @@ public class AdminController extends BaseController {
             description =
                     "Import projects from a CSV file. Expected columns: title,description,ownerEmail,status,maxTeamSize,category,requiredSkills")
     @Audited(action = "IMPORT_PROJECTS_CSV", entityType = "PROJECT")
-    public ResponseEntity<ApiResponse<ImportResultDTO>>
-            importProjects(
-                    @org.springframework.web.bind.annotation.RequestPart("file")
-                            org.springframework.web.multipart.MultipartFile file) {
+    public ResponseEntity<ApiResponse<ImportResultDTO>> importProjects(
+            @org.springframework.web.bind.annotation.RequestPart("file")
+                    org.springframework.web.multipart.MultipartFile file) {
         return send(
-                ImportProjectsFromCsvCommand.class,
-                null,
-                null,
-                null,
-                null,
-                Map.of("file", file));
+                ImportProjectsFromCsvCommand.class, null, null, null, null, Map.of("file", file));
     }
 
     // ==================== SCHEDULED EMAIL BROADCASTS ====================
@@ -544,16 +547,19 @@ public class AdminController extends BaseController {
     @Audited(action = "SCHEDULE_EMAIL", entityType = "EMAIL")
     public ResponseEntity<ApiResponse<Void>> scheduleEmail(
             @RequestBody ScheduleEmailRequest request) {
-        return send(new ScheduleEmailCommand(request.subject(), request.body(), request.targetRole(), request.scheduledAt()));
+        return send(
+                new ScheduleEmailCommand(
+                        request.subject(),
+                        request.body(),
+                        request.targetRole(),
+                        request.scheduledAt()));
     }
 
     @GetMapping("/email/scheduled")
     @Operation(
             summary = "List scheduled emails",
             description = "Get all scheduled email broadcasts")
-    public ResponseEntity<
-                    ApiResponse<List<ScheduledEmailDTO>>>
-            getScheduledEmails() {
+    public ResponseEntity<ApiResponse<List<ScheduledEmailDTO>>> getScheduledEmails() {
         return send(new GetScheduledEmailsQuery());
     }
 

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminController.java
@@ -1,23 +1,33 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.iyte_yazilim.proje_pazari.application.commands.adminDeleteProject.AdminDeleteProjectCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.adminDeleteUser.AdminDeleteUserCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.adminFeatureProject.AdminFeatureProjectCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.adminReviewApplication.AdminReviewApplicationCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.adminUpdateUser.AdminUpdateUserCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.banIp.BanIpCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.broadcastEmail.BroadcastEmailCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.bulkApplicationAction.BulkApplicationActionCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.bulkProjectAction.BulkProjectActionCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.bulkUserAction.BulkUserActionCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.cancelScheduledEmail.CancelScheduledEmailCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.flagContent.FlagContentCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.importProjectsFromCsv.ImportProjectsFromCsvCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.importUsersFromCsv.ImportUsersFromCsvCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.invalidateAllSessions.InvalidateAllSessionsCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.invalidateUserSessions.InvalidateUserSessionsCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.promoteToProjectOwner.PromoteToProjectOwnerCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.reviewFlaggedContent.ReviewFlaggedContentCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.scheduleEmail.ScheduleEmailCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.sendTargetedEmail.SendTargetedEmailCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.toggleMaintenanceMode.ToggleMaintenanceModeCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.unbanIp.UnbanIpCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.updateFeatureFlag.UpdateFeatureFlagCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.updateSystemConfig.UpdateSystemConfigCommand;
 import com.iyte_yazilim.proje_pazari.application.common.Audited;
 import com.iyte_yazilim.proje_pazari.application.dtos.ActiveSessionDTO;
+import com.iyte_yazilim.proje_pazari.application.dtos.AnalyticsTrendsDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.ApplicationAdminDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.ApplicationStatsDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.AuditLogDTO;
@@ -25,9 +35,11 @@ import com.iyte_yazilim.proje_pazari.application.dtos.BannedIpDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.BulkActionResult;
 import com.iyte_yazilim.proje_pazari.application.dtos.FeatureFlagDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.FlaggedContentDTO;
+import com.iyte_yazilim.proje_pazari.application.dtos.ImportResultDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.PagedResponse;
 import com.iyte_yazilim.proje_pazari.application.dtos.ProjectAdminDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.ProjectStatsDTO;
+import com.iyte_yazilim.proje_pazari.application.dtos.ScheduledEmailDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.SystemConfigDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.SystemHealthDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.SystemOverviewDTO;
@@ -47,10 +59,13 @@ import com.iyte_yazilim.proje_pazari.application.queries.getFeatureFlags.GetFeat
 import com.iyte_yazilim.proje_pazari.application.queries.getFlaggedContent.GetFlaggedContentQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getMaintenanceStatus.GetMaintenanceStatusQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getProjectStats.GetProjectStatsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.getScheduledEmails.GetScheduledEmailsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getSystemConfig.GetSystemConfigQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getSystemHealth.GetSystemHealthQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getSystemOverview.GetSystemOverviewQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getUserStats.GetUserStatsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.getAnalyticsTrends.GetAnalyticsTrendsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.listBannedIps.ListBannedIpsQuery;
 import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
 import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
@@ -58,6 +73,7 @@ import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.springframework.http.ResponseEntity;
@@ -107,18 +123,8 @@ public class AdminController extends BaseController {
     @Operation(summary = "Update user", description = "Update user role, status, or profile")
     @Audited(action = "ADMIN_UPDATE_USER", entityType = "USER")
     public ResponseEntity<ApiResponse<Void>> updateUser(
-            @PathVariable String userId, @RequestBody Map<String, Object> updates) {
-        RoleType role =
-                updates.containsKey("role") ? RoleType.valueOf((String) updates.get("role")) : null;
-        Boolean isActive =
-                updates.containsKey("isActive") ? (Boolean) updates.get("isActive") : null;
-        String firstName = (String) updates.get("firstName");
-        String lastName = (String) updates.get("lastName");
-        String description = (String) updates.get("description");
-
-        return send(
-                new AdminUpdateUserCommand(
-                        userId, role, isActive, firstName, lastName, description));
+            @PathVariable String userId, @RequestBody UpdateUserRequest request) {
+        return send(new AdminUpdateUserCommand(userId, request.role(), request.isActive(), request.firstName(), request.lastName(), request.description()));
     }
 
     @DeleteMapping("/users/{userId}")
@@ -135,11 +141,8 @@ public class AdminController extends BaseController {
                     "Perform bulk operations on users (DELETE, SUSPEND, ACTIVATE, CHANGE_ROLE)")
     @Audited(action = "BULK_USER_ACTION", entityType = "USER")
     public ResponseEntity<ApiResponse<BulkActionResult>> bulkUserAction(
-            @RequestBody Map<String, Object> request) {
-        String action = (String) request.get("action");
-        @SuppressWarnings("unchecked")
-        List<String> userIds = (List<String>) request.get("userIds");
-        return send(new BulkUserActionCommand(action, userIds));
+            @RequestBody BulkUserActionRequest request) {
+        return send(new BulkUserActionCommand(request.action(), request.userIds()));
     }
 
     @PostMapping("/users/{userId}/promote-to-project-owner")
@@ -190,11 +193,8 @@ public class AdminController extends BaseController {
                     "Perform bulk operations on projects (DELETE, FEATURE, UNFEATURE, CANCEL)")
     @Audited(action = "BULK_PROJECT_ACTION", entityType = "PROJECT")
     public ResponseEntity<ApiResponse<BulkActionResult>> bulkProjectAction(
-            @RequestBody Map<String, Object> request) {
-        String action = (String) request.get("action");
-        @SuppressWarnings("unchecked")
-        List<String> projectIds = (List<String>) request.get("projectIds");
-        return send(new BulkProjectActionCommand(action, projectIds));
+            @RequestBody BulkProjectActionRequest request) {
+        return send(new BulkProjectActionCommand(request.action(), request.projectIds()));
     }
 
     // ==================== APPLICATION MANAGEMENT ====================
@@ -218,10 +218,8 @@ public class AdminController extends BaseController {
             description = "Admin review of any application (approve/reject)")
     @Audited(action = "ADMIN_REVIEW_APPLICATION", entityType = "APPLICATION")
     public ResponseEntity<ApiResponse<Void>> reviewApplication(
-            @PathVariable String applicationId, @RequestBody Map<String, String> request) {
-        ApplicationStatus applicationStatus =
-                ApplicationStatus.valueOf(request.get("status").toUpperCase());
-        return send(new AdminReviewApplicationCommand(applicationId, applicationStatus));
+            @PathVariable String applicationId, @RequestBody ReviewApplicationRequest request) {
+        return send(new AdminReviewApplicationCommand(applicationId, request.status()));
     }
 
     @PostMapping("/applications/bulk-action")
@@ -230,11 +228,8 @@ public class AdminController extends BaseController {
             description = "Bulk approve/reject applications")
     @Audited(action = "BULK_APPLICATION_ACTION", entityType = "APPLICATION")
     public ResponseEntity<ApiResponse<BulkActionResult>> bulkApplicationAction(
-            @RequestBody Map<String, Object> request) {
-        String action = (String) request.get("action");
-        @SuppressWarnings("unchecked")
-        List<String> applicationIds = (List<String>) request.get("applicationIds");
-        return send(new BulkApplicationActionCommand(action, applicationIds));
+            @RequestBody BulkApplicationActionRequest request) {
+        return send(new BulkApplicationActionCommand(request.action(), request.applicationIds()));
     }
 
     // ==================== STATISTICS & ANALYTICS ====================
@@ -272,16 +267,9 @@ public class AdminController extends BaseController {
             summary = "Analytics trends",
             description =
                     "Get time-series trend data for user growth, project creation, and application activity")
-    public ResponseEntity<
-                    ApiResponse<com.iyte_yazilim.proje_pazari.application.dtos.AnalyticsTrendsDTO>>
+    public ResponseEntity<ApiResponse<AnalyticsTrendsDTO>>
             getAnalyticsTrends(@RequestParam(defaultValue = "30") int days) {
-        return send(
-                new com.iyte_yazilim
-                        .proje_pazari
-                        .application
-                        .queries
-                        .getAnalyticsTrends
-                        .GetAnalyticsTrendsQuery(days));
+        return send(new GetAnalyticsTrendsQuery(days));
     }
 
     // ==================== AUDIT LOGS ====================
@@ -308,9 +296,8 @@ public class AdminController extends BaseController {
     public ResponseEntity<ApiResponse<Void>> flagContent(
             @PathVariable String type,
             @PathVariable String id,
-            @RequestBody Map<String, String> request) {
-        String reason = request.getOrDefault("reason", "INAPPROPRIATE");
-        return send(new FlagContentCommand(type, id, reason));
+            @RequestBody FlagContentRequest request) {
+        return send(new FlagContentCommand(type, id, request.reason()));
     }
 
     @GetMapping("/content/flagged")
@@ -331,10 +318,8 @@ public class AdminController extends BaseController {
             description = "Review flagged content (APPROVE, REMOVE, BAN_USER)")
     @Audited(action = "REVIEW_FLAGGED_CONTENT", entityType = "CONTENT")
     public ResponseEntity<ApiResponse<Void>> reviewFlaggedContent(
-            @PathVariable String flagId, @RequestBody Map<String, String> request) {
-        String reviewAction = request.getOrDefault("action", "APPROVE");
-        String reviewNote = request.get("reviewNote");
-        return send(new ReviewFlaggedContentCommand(flagId, reviewAction, reviewNote));
+            @PathVariable String flagId, @RequestBody ReviewFlaggedContentRequest request) {
+        return send(new ReviewFlaggedContentCommand(flagId, request.action(), request.reviewNote()));
     }
 
     // ==================== EMAIL & NOTIFICATIONS ====================
@@ -345,23 +330,16 @@ public class AdminController extends BaseController {
             description = "Send email to all users or users with a specific role")
     @Audited(action = "BROADCAST_EMAIL", entityType = "EMAIL")
     public ResponseEntity<ApiResponse<Void>> broadcastEmail(
-            @RequestBody Map<String, String> request) {
-        String subject = request.get("subject");
-        String body = request.get("body");
-        String targetRole = request.getOrDefault("targetRole", "ALL");
-        return send(new BroadcastEmailCommand(subject, body, targetRole));
+            @RequestBody BroadcastEmailRequest request) {
+        return send(new BroadcastEmailCommand(request.subject(), request.body(), request.targetRole()));
     }
 
     @PostMapping("/email/targeted")
     @Operation(summary = "Send targeted email", description = "Send email to specific users by ID")
     @Audited(action = "TARGETED_EMAIL", entityType = "EMAIL")
     public ResponseEntity<ApiResponse<Void>> sendTargetedEmail(
-            @RequestBody Map<String, Object> request) {
-        String subject = (String) request.get("subject");
-        String body = (String) request.get("body");
-        @SuppressWarnings("unchecked")
-        List<String> userIds = (List<String>) request.get("userIds");
-        return send(new SendTargetedEmailCommand(userIds, subject, body));
+            @RequestBody SendTargetedEmailRequest request) {
+        return send(new SendTargetedEmailCommand(request.userIds(), request.subject(), request.body()));
     }
 
     // ==================== DATA EXPORT ====================
@@ -427,8 +405,8 @@ public class AdminController extends BaseController {
             description = "Update system configuration entries (key-value pairs)")
     @Audited(action = "UPDATE_SYSTEM_CONFIG", entityType = "SYSTEM")
     public ResponseEntity<ApiResponse<Void>> updateSystemConfig(
-            @RequestBody Map<String, String> configs) {
-        return send(new UpdateSystemConfigCommand(configs));
+            @RequestBody UpdateSystemConfigRequest request) {
+        return send(new UpdateSystemConfigCommand(request.configs()));
     }
 
     // ==================== FEATURE FLAGS ====================
@@ -447,10 +425,8 @@ public class AdminController extends BaseController {
             description = "Create or update a feature flag by key")
     @Audited(action = "UPDATE_FEATURE_FLAG", entityType = "FEATURE_FLAG")
     public ResponseEntity<ApiResponse<Void>> updateFeatureFlag(
-            @PathVariable String key, @RequestBody Map<String, Object> request) {
-        boolean enabled = request.containsKey("enabled") ? (Boolean) request.get("enabled") : false;
-        String description = (String) request.get("description");
-        return send(new UpdateFeatureFlagCommand(key, enabled, description));
+            @PathVariable String key, @RequestBody UpdateFeatureFlagRequest request) {
+        return send(new UpdateFeatureFlagCommand(key, request.enabled(), request.description()));
     }
 
     // ==================== MAINTENANCE MODE ====================
@@ -469,9 +445,8 @@ public class AdminController extends BaseController {
             description = "Enable or disable maintenance mode")
     @Audited(action = "TOGGLE_MAINTENANCE_MODE", entityType = "SYSTEM")
     public ResponseEntity<ApiResponse<Void>> toggleMaintenanceMode(
-            @RequestBody Map<String, Boolean> request) {
-        boolean enabled = request.getOrDefault("enabled", false);
-        return send(new ToggleMaintenanceModeCommand(enabled));
+            @RequestBody ToggleMaintenanceModeRequest request) {
+        return send(new ToggleMaintenanceModeCommand(request.enabled()));
     }
 
     // ==================== SESSION MANAGEMENT ====================
@@ -490,13 +465,7 @@ public class AdminController extends BaseController {
             description = "Revoke all sessions for a specific user")
     @Audited(action = "INVALIDATE_USER_SESSIONS", entityType = "SESSION")
     public ResponseEntity<ApiResponse<Void>> invalidateUserSessions(@PathVariable String userId) {
-        return send(
-                new com.iyte_yazilim
-                        .proje_pazari
-                        .application
-                        .commands
-                        .invalidateUserSessions
-                        .InvalidateUserSessionsCommand(userId));
+        return send(new InvalidateUserSessionsCommand(userId));
     }
 
     @DeleteMapping("/sessions")
@@ -505,13 +474,7 @@ public class AdminController extends BaseController {
             description = "Revoke all active sessions globally")
     @Audited(action = "INVALIDATE_ALL_SESSIONS", entityType = "SESSION")
     public ResponseEntity<ApiResponse<Void>> invalidateAllSessions() {
-        return send(
-                new com.iyte_yazilim
-                        .proje_pazari
-                        .application
-                        .commands
-                        .invalidateAllSessions
-                        .InvalidateAllSessionsCommand());
+        return send(new InvalidateAllSessionsCommand());
     }
 
     // ==================== IP BAN MANAGEMENT ====================
@@ -521,36 +484,21 @@ public class AdminController extends BaseController {
             summary = "Ban IP address",
             description = "Ban a specific IP address from accessing the platform")
     @Audited(action = "BAN_IP", entityType = "IP_BAN")
-    public ResponseEntity<ApiResponse<Void>> banIp(@RequestBody Map<String, Object> request) {
-        String ipAddress = (String) request.get("ipAddress");
-        String reason = (String) request.get("reason");
-        java.time.LocalDateTime expiresAt = null;
-        if (request.containsKey("expiresAt") && request.get("expiresAt") != null) {
-            expiresAt = java.time.LocalDateTime.parse((String) request.get("expiresAt"));
-        }
-        return send(
-                new com.iyte_yazilim.proje_pazari.application.commands.banIp.BanIpCommand(
-                        ipAddress, reason, expiresAt));
+    public ResponseEntity<ApiResponse<Void>> banIp(@RequestBody BanIpRequest request) {
+        return send(new BanIpCommand(request.ipAddress(), request.reason(), request.expiresAt()));
     }
 
     @DeleteMapping("/ip-bans/{ip}")
     @Operation(summary = "Unban IP address", description = "Remove an IP address from the ban list")
     @Audited(action = "UNBAN_IP", entityType = "IP_BAN")
     public ResponseEntity<ApiResponse<Void>> unbanIp(@PathVariable String ip) {
-        return send(
-                new com.iyte_yazilim.proje_pazari.application.commands.unbanIp.UnbanIpCommand(ip));
+        return send(new UnbanIpCommand(ip));
     }
 
     @GetMapping("/ip-bans")
     @Operation(summary = "List banned IPs", description = "Get all currently banned IP addresses")
     public ResponseEntity<ApiResponse<List<BannedIpDTO>>> listBannedIps() {
-        return send(
-                new com.iyte_yazilim
-                        .proje_pazari
-                        .application
-                        .queries
-                        .listBannedIps
-                        .ListBannedIpsQuery());
+        return send(new ListBannedIpsQuery());
     }
 
     // ==================== DATA IMPORT ====================
@@ -561,21 +509,14 @@ public class AdminController extends BaseController {
             description =
                     "Import users from a CSV file. Expected columns: email,firstName,lastName,role,password")
     @Audited(action = "IMPORT_USERS_CSV", entityType = "USER")
-    public ResponseEntity<
-                    ApiResponse<com.iyte_yazilim.proje_pazari.application.dtos.ImportResultDTO>>
+    public ResponseEntity<ApiResponse<ImportResultDTO>>
             importUsers(
                     @org.springframework.web.bind.annotation.RequestPart("file")
                             org.springframework.web.multipart.MultipartFile file) {
         try {
             String csvContent =
                     new String(file.getBytes(), java.nio.charset.StandardCharsets.UTF_8);
-            return send(
-                    new com.iyte_yazilim
-                            .proje_pazari
-                            .application
-                            .commands
-                            .importUsersFromCsv
-                            .ImportUsersFromCsvCommand(csvContent));
+            return send(new ImportUsersFromCsvCommand(csvContent));
         } catch (java.io.IOException e) {
             return ResponseEntity.badRequest()
                     .body(ApiResponse.validationError("Failed to read file: " + e.getMessage()));
@@ -588,21 +529,14 @@ public class AdminController extends BaseController {
             description =
                     "Import projects from a CSV file. Expected columns: title,description,ownerEmail,status,maxTeamSize,category,requiredSkills")
     @Audited(action = "IMPORT_PROJECTS_CSV", entityType = "PROJECT")
-    public ResponseEntity<
-                    ApiResponse<com.iyte_yazilim.proje_pazari.application.dtos.ImportResultDTO>>
+    public ResponseEntity<ApiResponse<ImportResultDTO>>
             importProjects(
                     @org.springframework.web.bind.annotation.RequestPart("file")
                             org.springframework.web.multipart.MultipartFile file) {
         try {
             String csvContent =
                     new String(file.getBytes(), java.nio.charset.StandardCharsets.UTF_8);
-            return send(
-                    new com.iyte_yazilim
-                            .proje_pazari
-                            .application
-                            .commands
-                            .importProjectsFromCsv
-                            .ImportProjectsFromCsvCommand(csvContent));
+            return send(new ImportProjectsFromCsvCommand(csvContent));
         } catch (java.io.IOException e) {
             return ResponseEntity.badRequest()
                     .body(ApiResponse.validationError("Failed to read file: " + e.getMessage()));
@@ -617,21 +551,8 @@ public class AdminController extends BaseController {
             description = "Schedule an email to be sent at a future date/time")
     @Audited(action = "SCHEDULE_EMAIL", entityType = "EMAIL")
     public ResponseEntity<ApiResponse<Void>> scheduleEmail(
-            @RequestBody Map<String, String> request) {
-        String subject = request.get("subject");
-        String body = request.get("body");
-        String targetRole = request.getOrDefault("targetRole", "ALL");
-        java.time.LocalDateTime scheduledAt = null;
-        if (request.containsKey("scheduledAt")) {
-            scheduledAt = java.time.LocalDateTime.parse(request.get("scheduledAt"));
-        }
-        return send(
-                new com.iyte_yazilim
-                        .proje_pazari
-                        .application
-                        .commands
-                        .scheduleEmail
-                        .ScheduleEmailCommand(subject, body, targetRole, scheduledAt));
+            @RequestBody ScheduleEmailRequest request) {
+        return send(new ScheduleEmailCommand(request.subject(), request.body(), request.targetRole(), request.scheduledAt()));
     }
 
     @GetMapping("/email/scheduled")
@@ -639,16 +560,9 @@ public class AdminController extends BaseController {
             summary = "List scheduled emails",
             description = "Get all scheduled email broadcasts")
     public ResponseEntity<
-                    ApiResponse<
-                            List<com.iyte_yazilim.proje_pazari.application.dtos.ScheduledEmailDTO>>>
+                    ApiResponse<List<ScheduledEmailDTO>>>
             getScheduledEmails() {
-        return send(
-                new com.iyte_yazilim
-                        .proje_pazari
-                        .application
-                        .queries
-                        .getScheduledEmails
-                        .GetScheduledEmailsQuery());
+        return send(new GetScheduledEmailsQuery());
     }
 
     @DeleteMapping("/email/scheduled/{id}")
@@ -657,12 +571,43 @@ public class AdminController extends BaseController {
             description = "Cancel a pending scheduled email broadcast")
     @Audited(action = "CANCEL_SCHEDULED_EMAIL", entityType = "EMAIL")
     public ResponseEntity<ApiResponse<Void>> cancelScheduledEmail(@PathVariable String id) {
-        return send(
-                new com.iyte_yazilim
-                        .proje_pazari
-                        .application
-                        .commands
-                        .cancelScheduledEmail
-                        .CancelScheduledEmailCommand(id));
+        return send(new CancelScheduledEmailCommand(id));
     }
+
+    public record UpdateUserRequest(
+            RoleType role,
+            Boolean isActive,
+            String firstName,
+            String lastName,
+            String description) {}
+
+    public record BulkUserActionRequest(String action, List<String> userIds) {}
+
+    public record BulkProjectActionRequest(String action, List<String> projectIds) {}
+
+    public record ReviewApplicationRequest(ApplicationStatus status) {}
+
+    public record BulkApplicationActionRequest(String action, List<String> applicationIds) {}
+
+    public record FlagContentRequest(String reason) {}
+
+    public record ReviewFlaggedContentRequest(String action, String reviewNote) {}
+
+    public record BroadcastEmailRequest(String subject, String body, String targetRole) {}
+
+    public record SendTargetedEmailRequest(List<String> userIds, String subject, String body) {}
+
+    public record UpdateSystemConfigRequest(Map<String, String> configs) {
+        @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+        public UpdateSystemConfigRequest {}
+    }
+
+    public record UpdateFeatureFlagRequest(boolean enabled, String description) {}
+
+    public record ToggleMaintenanceModeRequest(boolean enabled) {}
+
+    public record BanIpRequest(String ipAddress, String reason, LocalDateTime expiresAt) {}
+
+    public record ScheduleEmailRequest(
+            String subject, String body, String targetRole, LocalDateTime scheduledAt) {}
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
@@ -77,7 +77,8 @@ public class AuthController extends BaseController {
 
     public AuthController(
             IRequestHandler<VerifyEmailCommand, ApiResponse<VerifyEmailResult>> verifyEmailHandler,
-            IRequestHandler<ResendVerificationEmailCommand, ApiResponse<Void>> resendVerificationEmailHandler) {
+            IRequestHandler<ResendVerificationEmailCommand, ApiResponse<Void>>
+                    resendVerificationEmailHandler) {
         this.verifyEmailHandler = verifyEmailHandler;
         this.resendVerificationEmailHandler = resendVerificationEmailHandler;
     }
@@ -284,7 +285,8 @@ public class AuthController extends BaseController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<RefreshTokenResult>> refreshToken(@RequestParam String refreshToken) {
+    public ResponseEntity<ApiResponse<RefreshTokenResult>> refreshToken(
+            @RequestParam String refreshToken) {
         return send(new RefreshTokenCommand(refreshToken));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
@@ -1,6 +1,8 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import com.iyte_yazilim.proje_pazari.application.commands.loginUser.LoginUserCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.refreshToken.RefreshTokenCommand;
+import com.iyte_yazilim.proje_pazari.application.commands.refreshToken.RefreshTokenResult;
 import com.iyte_yazilim.proje_pazari.application.commands.registerUser.RegisterUserCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.resendVerificationEmail.ResendVerificationEmailCommand;
 import com.iyte_yazilim.proje_pazari.application.commands.verifyEmail.VerifyEmailCommand;
@@ -9,10 +11,6 @@ import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.domain.models.results.LoginUserResult;
 import com.iyte_yazilim.proje_pazari.domain.models.results.RegisterUserResult;
 import com.iyte_yazilim.proje_pazari.domain.models.results.VerifyEmailResult;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
-import com.iyte_yazilim.proje_pazari.infrastructure.security.service.RefreshTokenService;
-import com.iyte_yazilim.proje_pazari.presentation.security.JwtUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -76,22 +74,12 @@ public class AuthController extends BaseController {
             verifyEmailHandler;
     private final IRequestHandler<ResendVerificationEmailCommand, ApiResponse<Void>>
             resendVerificationEmailHandler;
-    private final RefreshTokenService refreshTokenService;
-    private final JwtUtil jwtUtil;
-    private final UserRepository userRepository;
 
     public AuthController(
             IRequestHandler<VerifyEmailCommand, ApiResponse<VerifyEmailResult>> verifyEmailHandler,
-            IRequestHandler<ResendVerificationEmailCommand, ApiResponse<Void>>
-                    resendVerificationEmailHandler,
-            RefreshTokenService refreshTokenService,
-            JwtUtil jwtUtil,
-            UserRepository userRepository) {
+            IRequestHandler<ResendVerificationEmailCommand, ApiResponse<Void>> resendVerificationEmailHandler) {
         this.verifyEmailHandler = verifyEmailHandler;
         this.resendVerificationEmailHandler = resendVerificationEmailHandler;
-        this.refreshTokenService = refreshTokenService;
-        this.jwtUtil = jwtUtil;
-        this.userRepository = userRepository;
     }
 
     @PostMapping("/register")
@@ -296,48 +284,7 @@ public class AuthController extends BaseController {
     }
 
     @PostMapping("/refresh")
-    @Operation(
-            summary = "Refresh access token",
-            description =
-                    "Exchanges a valid refresh token for a new access token and refresh token")
-    @ApiResponses(
-            value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "Token refreshed successfully"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "400",
-                        description = "Invalid or expired refresh token")
-            })
-    public ResponseEntity<ApiResponse<LoginUserResult>> refreshToken(
-            @RequestParam String refreshToken) {
-        var userIdOpt = refreshTokenService.validateRefreshToken(refreshToken);
-        if (userIdOpt.isEmpty()) {
-            return ResponseEntity.badRequest()
-                    .body(ApiResponse.badRequest("Invalid or expired refresh token"));
-        }
-
-        String userId = userIdOpt.get();
-        UserEntity user = userRepository.findById(userId).orElse(null);
-        if (user == null) {
-            return ResponseEntity.badRequest().body(ApiResponse.badRequest("User not found"));
-        }
-
-        refreshTokenService.revokeRefreshToken(refreshToken);
-        String newRefreshToken = refreshTokenService.createRefreshToken(userId);
-        String role = user.getRole() != null ? user.getRole().toString() : "APPLICANT";
-        String newAccessToken = jwtUtil.generateToken(user.getId(), user.getEmail(), role);
-
-        var result =
-                new LoginUserResult(
-                        user.getId(),
-                        user.getEmail(),
-                        user.getFirstName(),
-                        user.getLastName(),
-                        role,
-                        newAccessToken,
-                        newRefreshToken,
-                        null);
-        return ResponseEntity.ok(ApiResponse.success(result, "Token refreshed successfully"));
+    public ResponseEntity<ApiResponse<RefreshTokenResult>> refreshToken(@RequestParam String refreshToken) {
+        return send(new RefreshTokenCommand(refreshToken));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -1,8 +1,7 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
+import com.iyte_yazilim.proje_pazari.application.commands.uploadFile.UploadFileCommand;
 import com.iyte_yazilim.proje_pazari.application.queries.downloadFile.DownloadFileQuery;
-import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -33,8 +32,6 @@ import org.springframework.web.multipart.MultipartFile;
 public class FileController extends BaseController {
 
     private static final int DEFAULT_EXPIRY_MINUTES = 60;
-
-    private final FileStorageService fileStorageService;
 
     @GetMapping("/{*path}")
     @PreAuthorize("permitAll()")
@@ -122,41 +119,6 @@ public class FileController extends BaseController {
                             content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
                     @RequestParam("file")
                     MultipartFile file) {
-        try {
-            if (file.isEmpty()) {
-                return ResponseEntity.badRequest().body(ApiResponse.error("File is empty"));
-            }
-
-            // Validate file - check for null/empty filename
-            String filename = file.getOriginalFilename();
-            if (filename == null || filename.isBlank()) {
-                return ResponseEntity.badRequest().body(ApiResponse.error("Invalid filename"));
-            }
-
-            // Check for path traversal attacks
-            if (filename.contains("..")) {
-                return ResponseEntity.badRequest().body(ApiResponse.error("Invalid filename"));
-            }
-
-            // Store file and get the path (using "uploads" as default directory)
-            String filePath = fileStorageService.storeFile(file, "uploads");
-
-            // Get file size
-            long fileSize = file.getSize();
-
-            // Build response
-            Map<String, Object> fileData =
-                    Map.of(
-                            "filename", filename,
-                            "url", "/api/v1/files/" + filePath,
-                            "size", fileSize);
-
-            return ResponseEntity.ok(ApiResponse.success(fileData, "File uploaded successfully"));
-
-        } catch (FileStorageException e) {
-            log.error("File upload failed: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.error("File upload failed: " + e.getMessage()));
-        }
+        return send(UploadFileCommand.class, null, null, null, null, Map.of("file", file));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
@@ -1,11 +1,11 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import com.iyte_yazilim.proje_pazari.application.commands.createProject.CreateProjectCommand;
+import com.iyte_yazilim.proje_pazari.application.queries.getAllProjects.GetAllProjectsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.getProjectById.GetProjectByIdQuery;
 import com.iyte_yazilim.proje_pazari.domain.entities.Project;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.domain.models.results.CreateProjectCommandResult;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers.ProjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -30,8 +30,6 @@ import org.springframework.web.bind.annotation.*;
                 "Project management endpoints. "
                         + "Allows users to create, read, update, and delete projects.")
 public class ProjectController extends BaseController {
-    private final ProjectRepository projectRepository;
-    private final ProjectMapper projectMapper;
 
     @PostMapping
     @PreAuthorize("isAuthenticated() and hasRole('PROJECT_OWNER')")
@@ -169,10 +167,7 @@ public class ProjectController extends BaseController {
                         description = "Internal server error")
             })
     public ResponseEntity<ApiResponse<List<Project>>> getAllProjects() {
-        List<Project> projects =
-                projectRepository.findAll().stream().map(projectMapper::entityToDomain).toList();
-
-        return ResponseEntity.ok(ApiResponse.success(projects, "Projects retrieved successfully"));
+        return send(new GetAllProjectsQuery());
     }
 
     @GetMapping("/{projectId}")
@@ -190,14 +185,6 @@ public class ProjectController extends BaseController {
                         description = "Project not found")
             })
     public ResponseEntity<ApiResponse<Project>> getProject(@PathVariable String projectId) {
-        return projectRepository
-                .findById(projectId)
-                .map(
-                        entity -> {
-                            Project project = projectMapper.entityToDomain(entity);
-                            return ResponseEntity.ok(
-                                    ApiResponse.success(project, "Project retrieved successfully"));
-                        })
-                .orElse(ResponseEntity.notFound().build());
+        return send(new GetProjectByIdQuery(projectId));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
@@ -1,7 +1,8 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
+import com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics.GetProjectStatisticsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.searchProjects.SearchProjectsQuery;
-import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.application.queries.suggestProjects.SuggestProjectsQuery;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,8 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SearchController extends BaseController {
 
-    private final ProjectSearchService searchService;
-
     @GetMapping("/projects")
     public ResponseEntity<ApiResponse<List<ProjectDocument>>> searchProjects(
             @RequestParam @NotBlank @Size(min = 2, max = 100) String q,
@@ -42,15 +41,13 @@ public class SearchController extends BaseController {
     }
 
     @GetMapping("/projects/suggest")
-    public ApiResponse<List<String>> suggestProjects(
+    public ResponseEntity<ApiResponse<List<String>>> suggestProjects(
             @RequestParam @NotBlank @Size(min = 1, max = 100) String q) {
-        List<String> suggestions = searchService.getSuggestions(q);
-        return ApiResponse.success(suggestions, "Suggestions retrieved successfully");
+        return send(new SuggestProjectsQuery(q));
     }
 
     @GetMapping("/projects/statistics")
-    public ApiResponse<Map<String, Long>> getStatistics() {
-        Map<String, Long> stats = searchService.getProjectStatistics();
-        return ApiResponse.success(stats, "Statistics retrieved successfully");
+    public ResponseEntity<ApiResponse<Map<String, Long>>> getStatistics() {
+        return send(new GetProjectStatisticsQuery());
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AdminControllerTest.java
@@ -188,10 +188,10 @@ class AdminControllerTest {
             when(mediator.send(any(BulkUserActionCommand.class)))
                     .thenReturn(ApiResponse.success(result, "Bulk action completed"));
 
-            Map<String, Object> request =
-                    Map.of("action", "SUSPEND", "userIds", List.of("user-1", "user-2"));
             ResponseEntity<ApiResponse<BulkActionResult>> response =
-                    adminController.bulkUserAction(request);
+                    adminController.bulkUserAction(
+                            new AdminController.BulkUserActionRequest(
+                                    "SUSPEND", List.of("user-1", "user-2")));
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
             assertEquals(1, response.getBody().getData().getSuccessCount());
@@ -232,7 +232,8 @@ class AdminControllerTest {
                     .thenReturn(ApiResponse.success(null, "Content flagged successfully"));
 
             ResponseEntity<ApiResponse<Void>> response =
-                    adminController.flagContent("PROJECT", "proj-1", Map.of("reason", "SPAM"));
+                    adminController.flagContent(
+                            "PROJECT", "proj-1", new AdminController.FlagContentRequest("SPAM"));
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
         }
@@ -294,7 +295,8 @@ class AdminControllerTest {
                     .thenReturn(ApiResponse.success(null, "Config updated"));
 
             ResponseEntity<ApiResponse<Void>> response =
-                    adminController.updateSystemConfig(Map.of("key", "value"));
+                    adminController.updateSystemConfig(
+                            new AdminController.UpdateSystemConfigRequest(Map.of("key", "value")));
 
             assertEquals(HttpStatus.OK, response.getStatusCode());
         }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
@@ -312,8 +312,7 @@ class SearchControllerTest {
                     List.of("Java Spring Boot Project", "Java Backend Application");
             when(mediator.send(any(SuggestProjectsQuery.class)))
                     .thenReturn(
-                            ApiResponse.success(
-                                    suggestions, "Suggestions retrieved successfully"));
+                            ApiResponse.success(suggestions, "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "java"))
                     .andExpect(status().isOk())
@@ -391,8 +390,7 @@ class SearchControllerTest {
         void shouldReturnStatisticsSuccessfully() throws Exception {
             Map<String, Long> stats = Map.of("ACTIVE", 10L, "COMPLETED", 5L, "DRAFT", 3L);
             when(mediator.send(any(GetProjectStatisticsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(stats, "Statistics retrieved successfully"));
+                    .thenReturn(ApiResponse.success(stats, "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
@@ -10,9 +10,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
+import com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics.GetProjectStatisticsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.searchProjects.SearchProjectsQuery;
+import com.iyte_yazilim.proje_pazari.application.queries.suggestProjects.SuggestProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
@@ -56,8 +57,6 @@ class SearchControllerTest {
     @MockitoBean private MessageService messageService;
 
     @MockitoBean private UserRepository userRepository;
-
-    @MockitoBean private ProjectSearchService searchService;
 
     @MockitoBean
     private com.iyte_yazilim.proje_pazari.domain.interfaces.TokenBlacklistService
@@ -311,7 +310,10 @@ class SearchControllerTest {
         void shouldReturnSuggestionsWhenQueryIsValid() throws Exception {
             List<String> suggestions =
                     List.of("Java Spring Boot Project", "Java Backend Application");
-            when(searchService.getSuggestions("java")).thenReturn(suggestions);
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    suggestions, "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "java"))
                     .andExpect(status().isOk())
@@ -321,14 +323,17 @@ class SearchControllerTest {
                     .andExpect(jsonPath("$.data[0]").value("Java Spring Boot Project"))
                     .andExpect(jsonPath("$.data[1]").value("Java Backend Application"));
 
-            verify(searchService).getSuggestions("java");
+            verify(mediator).send(any(SuggestProjectsQuery.class));
         }
 
         @Test
         @WithMockUser
         @DisplayName("Should return empty list when no suggestions found")
         void shouldReturnEmptyListWhenNoSuggestionsFound() throws Exception {
-            when(searchService.getSuggestions("xyz")).thenReturn(Collections.emptyList());
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    Collections.emptyList(), "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "xyz"))
                     .andExpect(status().isOk())
@@ -340,7 +345,10 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("Should accept single character query")
         void shouldAcceptSingleCharacterQuery() throws Exception {
-            when(searchService.getSuggestions("j")).thenReturn(List.of("Java Project"));
+            when(mediator.send(any(SuggestProjectsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    List.of("Java Project"), "Suggestions retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/suggest").param("q", "j"))
                     .andExpect(status().isOk())
@@ -382,7 +390,9 @@ class SearchControllerTest {
         @DisplayName("Should return statistics successfully")
         void shouldReturnStatisticsSuccessfully() throws Exception {
             Map<String, Long> stats = Map.of("ACTIVE", 10L, "COMPLETED", 5L, "DRAFT", 3L);
-            when(searchService.getProjectStatistics()).thenReturn(stats);
+            when(mediator.send(any(GetProjectStatisticsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(stats, "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())
@@ -392,14 +402,17 @@ class SearchControllerTest {
                     .andExpect(jsonPath("$.data.COMPLETED").value(5))
                     .andExpect(jsonPath("$.data.DRAFT").value(3));
 
-            verify(searchService).getProjectStatistics();
+            verify(mediator).send(any(GetProjectStatisticsQuery.class));
         }
 
         @Test
         @WithMockUser
         @DisplayName("Should return empty statistics when no data")
         void shouldReturnEmptyStatisticsWhenNoData() throws Exception {
-            when(searchService.getProjectStatistics()).thenReturn(Collections.emptyMap());
+            when(mediator.send(any(GetProjectStatisticsQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    Collections.emptyMap(), "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())


### PR DESCRIPTION
## Motivation & Context
This PR strictly enforces the established Clean Architecture and CQRS patterns across the application. Previously, some controllers contained embedded business logic, manual data parsing (e.g., Map<String, Object>, LocalDateTime.parse), and direct service/repository interactions. This refactoring guarantees that controllers remain "thin" and act solely as HTTP entry points.

## Key Changes

Auth Domain: Extracted all token validation and regeneration logic from AuthController.refreshToken() into a dedicated RefreshTokenCommand and RefreshTokenHandler.

Admin & Elasticsearch Domains: Refactored AdminController and ElasticsearchAdminController to eliminate raw Map request bodies. Replaced them with strongly-typed Request Records/Commands.

Data Parsing: Removed manual date and Enum parsing from controllers, shifting the responsibility to Spring's Jackson deserializer and domain Validators.

Standardization: Ensured all refactored endpoints strictly follow the receive -> send() -> return pattern via BaseController.

## Acceptance Criteria Checklist

[✅] AuthController.refreshToken() delegates entirely to a RefreshTokenHandler via mediator.

[✅] No controller directly accesses a repository.

[✅] No controller directly calls service methods for business operations.

[✅] All refactored controller methods strictly follow the pattern: receive → send() → return.

[✅] Existing refresh token tests pass with the new structure.