### PR TITLE
Fix/missing message key and localdatetime deserialization

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapper.java
@@ -2,6 +2,8 @@ package com.iyte_yazilim.proje_pazari.presentation.mappers;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.presentation.security.UserPrincipal;
 import java.lang.reflect.Constructor;
@@ -24,6 +26,8 @@ public class AutoRequestMapper implements IRequestMapper {
     public AutoRequestMapper() {
         this.objectMapper =
                 new ObjectMapper()
+                        .registerModule(new JavaTimeModule())
+                        .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
                         .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -5,6 +5,7 @@ auth.login.failed=Geçersiz kullanıcı adı veya şifre
 auth.logout.success=Çıkış başarılı
 auth.token.invalid=Geçersiz token
 auth.token.expired=Token süresi dolmuş
+auth.token.refreshed=Token başarıyla yenilendi
 auth.email.already.registered=Bu e-posta adresi zaten kayıtlı
 auth.account.deactivated=Hesap devre dışı bırakılmış
 

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -5,6 +5,7 @@ auth.login.failed=Invalid username or password
 auth.logout.success=Logout successful
 auth.token.invalid=Invalid token
 auth.token.expired=Token expired
+auth.token.refreshed=Token refreshed successfully
 auth.email.already.registered=This email address is already registered
 auth.account.deactivated=Account has been deactivated
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/mappers/AutoRequestMapperTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.presentation.security.UserPrincipal;
+import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,6 +30,8 @@ class AutoRequestMapperTest {
             implements IRequest<Void> {}
 
     public record FileUploadCommand(String userId, MultipartFile file) implements IRequest<Void> {}
+
+    public record DateCommand(LocalDateTime deadline, String title) implements IRequest<Void> {}
 
     public record EmptyCommand() implements IRequest<Void> {}
 
@@ -59,6 +62,16 @@ class AutoRequestMapperTest {
 
             assertEquals("Alice", result.name());
             assertEquals(25, result.age());
+        }
+
+        @Test
+        @DisplayName("should map LocalDateTime from body")
+        void shouldMapLocalDateTime() {
+            DateCommand body = new DateCommand(LocalDateTime.of(2026, 6, 1, 12, 0), "Test");
+
+            DateCommand result = mapper.map(DateCommand.class, null, null, body, null);
+
+            assertEquals(LocalDateTime.of(2026, 6, 1, 12, 0), result.deadline());
         }
 
         @Test


### PR DESCRIPTION
This pull request introduces enhancements to date handling in the request mapping logic and adds a new localized message for token refresh events. The main changes are grouped below:

Improvements to date serialization/deserialization:

* [`AutoRequestMapper.java`](diffhunk://#diff-eb44bf1cf0396edec90a6e51c86e036db179fc92c41ea593425c5cf8c1c1a659R5-R6): The `ObjectMapper` is now configured to register the `JavaTimeModule` and to serialize dates in ISO-8601 format instead of timestamps, improving compatibility with Java date/time types. [[1]](diffhunk://#diff-eb44bf1cf0396edec90a6e51c86e036db179fc92c41ea593425c5cf8c1c1a659R5-R6) [[2]](diffhunk://#diff-eb44bf1cf0396edec90a6e51c86e036db179fc92c41ea593425c5cf8c1c1a659R29-R30)

Localization updates for authentication messages:

* [`messages.properties`](diffhunk://#diff-0771b708161a9fbc2a5e9a05637222f39afce6e028cd010abcbaaaee1ade7653R8): Added a new Turkish message for successful token refresh: `auth.token.refreshed=Token başarıyla yenilendi`.
* [`messages_en.properties`](diffhunk://#diff-bee834de92f1787bd538724a93a45f483cd2f7d6bc8b971e0670603d10902743R8): Added a new English message for successful token refresh: `auth.token.refreshed=Token refreshed successfully`.