### PR TITLE
fix: complete domain exception handling refactoring (Issue #65)

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteProject/AdminDeleteProjectHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteProject/AdminDeleteProjectHandler.java
@@ -19,8 +19,10 @@ public class AdminDeleteProjectHandler
     @Override
     @Transactional
     public ApiResponse<Void> handle(AdminDeleteProjectCommand command) {
-        ProjectEntity project = projectRepository.findById(command.projectId())
-                .orElseThrow(() -> new ProjectNotFoundException(command.projectId()));
+        ProjectEntity project =
+                projectRepository
+                        .findById(command.projectId())
+                        .orElseThrow(() -> new ProjectNotFoundException(command.projectId()));
 
         projectRepository.delete(project);
         return ApiResponse.success(null, "Project deleted successfully");

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteProject/AdminDeleteProjectHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteProject/AdminDeleteProjectHandler.java
@@ -1,5 +1,6 @@
 package com.iyte_yazilim.proje_pazari.application.commands.adminDeleteProject;
 
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
@@ -18,11 +19,8 @@ public class AdminDeleteProjectHandler
     @Override
     @Transactional
     public ApiResponse<Void> handle(AdminDeleteProjectCommand command) {
-        ProjectEntity project = projectRepository.findById(command.projectId()).orElse(null);
-
-        if (project == null) {
-            return ApiResponse.notFound("Project not found with id: " + command.projectId());
-        }
+        ProjectEntity project = projectRepository.findById(command.projectId())
+                .orElseThrow(() -> new ProjectNotFoundException(command.projectId()));
 
         projectRepository.delete(project);
         return ApiResponse.success(null, "Project deleted successfully");

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteUser/AdminDeleteUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteUser/AdminDeleteUserHandler.java
@@ -19,8 +19,10 @@ public class AdminDeleteUserHandler
     @Override
     @Transactional
     public ApiResponse<Void> handle(AdminDeleteUserCommand command) {
-        UserEntity user = userRepository.findById(command.userId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+        UserEntity user =
+                userRepository
+                        .findById(command.userId())
+                        .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Soft delete: deactivate the user
         user.setIsActive(false);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteUser/AdminDeleteUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteUser/AdminDeleteUserHandler.java
@@ -19,11 +19,8 @@ public class AdminDeleteUserHandler
     @Override
     @Transactional
     public ApiResponse<Void> handle(AdminDeleteUserCommand command) {
-        UserEntity user = userRepository.findById(command.userId()).orElse(null);
-
-        if (user == null) {
-            throw new UserNotFoundException("User not found with id: " + command.userId());
-        }
+        UserEntity user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Soft delete: deactivate the user
         user.setIsActive(false);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandler.java
@@ -1,5 +1,6 @@
 package com.iyte_yazilim.proje_pazari.application.commands.adminReviewApplication;
 
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectApplicationRepository;
@@ -19,12 +20,8 @@ public class AdminReviewApplicationHandler
     @Transactional
     public ApiResponse<Void> handle(AdminReviewApplicationCommand command) {
         ProjectApplicationEntity application =
-                applicationRepository.findById(command.applicationId()).orElse(null);
-
-        if (application == null) {
-            return ApiResponse.notFound(
-                    "Application not found with id: " + command.applicationId());
-        }
+                applicationRepository.findById(command.applicationId())
+                        .orElseThrow(() -> new ApplicationNotFoundException(command.applicationId()));
 
         application.setStatus(command.status());
         applicationRepository.save(application);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandler.java
@@ -20,8 +20,10 @@ public class AdminReviewApplicationHandler
     @Transactional
     public ApiResponse<Void> handle(AdminReviewApplicationCommand command) {
         ProjectApplicationEntity application =
-                applicationRepository.findById(command.applicationId())
-                        .orElseThrow(() -> new ApplicationNotFoundException(command.applicationId()));
+                applicationRepository
+                        .findById(command.applicationId())
+                        .orElseThrow(
+                                () -> new ApplicationNotFoundException(command.applicationId()));
 
         application.setStatus(command.status());
         applicationRepository.save(application);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminUpdateUser/AdminUpdateUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminUpdateUser/AdminUpdateUserHandler.java
@@ -19,8 +19,10 @@ public class AdminUpdateUserHandler
     @Override
     @Transactional
     public ApiResponse<Void> handle(AdminUpdateUserCommand command) {
-        UserEntity user = userRepository.findById(command.userId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+        UserEntity user =
+                userRepository
+                        .findById(command.userId())
+                        .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         if (command.role() != null) {
             user.setRole(command.role());

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminUpdateUser/AdminUpdateUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminUpdateUser/AdminUpdateUserHandler.java
@@ -1,5 +1,6 @@
 package com.iyte_yazilim.proje_pazari.application.commands.adminUpdateUser;
 
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -18,11 +19,8 @@ public class AdminUpdateUserHandler
     @Override
     @Transactional
     public ApiResponse<Void> handle(AdminUpdateUserCommand command) {
-        UserEntity user = userRepository.findById(command.userId()).orElse(null);
-
-        if (user == null) {
-            return ApiResponse.notFound("User not found with id: " + command.userId());
-        }
+        UserEntity user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         if (command.role() != null) {
             user.setRole(command.role());

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandler.java
@@ -28,8 +28,13 @@ public class BulkApplicationActionHandler
 
         for (String appId : command.applicationIds()) {
             try {
-                ProjectApplicationEntity app = applicationRepository.findById(appId)
-                    .orElseThrow(() -> new com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException(appId));
+                ProjectApplicationEntity app =
+                        applicationRepository
+                                .findById(appId)
+                                .orElseThrow(
+                                        () ->
+                                                new com.iyte_yazilim.proje_pazari.domain.exceptions
+                                                        .ApplicationNotFoundException(appId));
 
                 switch (command.action().toUpperCase()) {
                     case "APPROVE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandler.java
@@ -28,11 +28,8 @@ public class BulkApplicationActionHandler
 
         for (String appId : command.applicationIds()) {
             try {
-                ProjectApplicationEntity app = applicationRepository.findById(appId).orElse(null);
-                if (app == null) {
-                    result.addFailure(appId, "Application not found");
-                    continue;
-                }
+                ProjectApplicationEntity app = applicationRepository.findById(appId)
+                    .orElseThrow(() -> new com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException(appId));
 
                 switch (command.action().toUpperCase()) {
                     case "APPROVE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandler.java
@@ -2,6 +2,7 @@ package com.iyte_yazilim.proje_pazari.application.commands.bulkApplicationAction
 
 import com.iyte_yazilim.proje_pazari.application.dtos.BulkActionResult;
 import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectApplicationRepository;
@@ -31,10 +32,7 @@ public class BulkApplicationActionHandler
                 ProjectApplicationEntity app =
                         applicationRepository
                                 .findById(appId)
-                                .orElseThrow(
-                                        () ->
-                                                new com.iyte_yazilim.proje_pazari.domain.exceptions
-                                                        .ApplicationNotFoundException(appId));
+                                .orElseThrow(() -> new ApplicationNotFoundException(appId));
 
                 switch (command.action().toUpperCase()) {
                     case "APPROVE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkProjectAction/BulkProjectActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkProjectAction/BulkProjectActionHandler.java
@@ -28,11 +28,13 @@ public class BulkProjectActionHandler
 
         for (String projectId : command.projectIds()) {
             try {
-                ProjectEntity project = projectRepository.findById(projectId).orElse(null);
-                if (project == null) {
-                    result.addFailure(projectId, "Project not found");
-                    continue;
-                }
+                ProjectEntity project =
+                        projectRepository
+                                .findById(projectId)
+                                .orElseThrow(
+                                        () ->
+                                                new com.iyte_yazilim.proje_pazari.domain.exceptions
+                                                        .ProjectNotFoundException(projectId));
 
                 switch (command.action().toUpperCase()) {
                     case "DELETE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkProjectAction/BulkProjectActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkProjectAction/BulkProjectActionHandler.java
@@ -2,6 +2,7 @@ package com.iyte_yazilim.proje_pazari.application.commands.bulkProjectAction;
 
 import com.iyte_yazilim.proje_pazari.application.dtos.BulkActionResult;
 import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
@@ -31,10 +32,7 @@ public class BulkProjectActionHandler
                 ProjectEntity project =
                         projectRepository
                                 .findById(projectId)
-                                .orElseThrow(
-                                        () ->
-                                                new com.iyte_yazilim.proje_pazari.domain.exceptions
-                                                        .ProjectNotFoundException(projectId));
+                                .orElseThrow(() -> new ProjectNotFoundException(projectId));
 
                 switch (command.action().toUpperCase()) {
                     case "DELETE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkUserAction/BulkUserActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkUserAction/BulkUserActionHandler.java
@@ -2,6 +2,7 @@ package com.iyte_yazilim.proje_pazari.application.commands.bulkUserAction;
 
 import com.iyte_yazilim.proje_pazari.application.dtos.BulkActionResult;
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -31,10 +32,7 @@ public class BulkUserActionHandler
                 UserEntity user =
                         userRepository
                                 .findById(userId)
-                                .orElseThrow(
-                                        () ->
-                                                new com.iyte_yazilim.proje_pazari.domain.exceptions
-                                                        .UserNotFoundException(userId));
+                                .orElseThrow(() -> new UserNotFoundException(userId));
 
                 switch (command.action().toUpperCase()) {
                     case "DELETE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkUserAction/BulkUserActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkUserAction/BulkUserActionHandler.java
@@ -28,8 +28,13 @@ public class BulkUserActionHandler
 
         for (String userId : command.userIds()) {
             try {
-                UserEntity user = userRepository.findById(userId)
-                    .orElseThrow(() -> new com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException(userId));
+                UserEntity user =
+                        userRepository
+                                .findById(userId)
+                                .orElseThrow(
+                                        () ->
+                                                new com.iyte_yazilim.proje_pazari.domain.exceptions
+                                                        .UserNotFoundException(userId));
 
                 switch (command.action().toUpperCase()) {
                     case "DELETE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkUserAction/BulkUserActionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/bulkUserAction/BulkUserActionHandler.java
@@ -28,11 +28,8 @@ public class BulkUserActionHandler
 
         for (String userId : command.userIds()) {
             try {
-                UserEntity user = userRepository.findById(userId).orElse(null);
-                if (user == null) {
-                    result.addFailure(userId, "User not found");
-                    continue;
-                }
+                UserEntity user = userRepository.findById(userId)
+                    .orElseThrow(() -> new com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException(userId));
 
                 switch (command.action().toUpperCase()) {
                     case "DELETE":

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/changePassword/ChangePasswordHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/changePassword/ChangePasswordHandler.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.commands.changePassword;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -34,11 +35,8 @@ public class ChangePasswordHandler
             return ApiResponse.validationError(e.getMessage());
         }
 
-        UserEntity user = userRepository.findById(command.userId()).orElse(null);
-
-        if (user == null) {
-            return ApiResponse.notFound(messageService.getMessage("user.not.found"));
-        }
+        UserEntity user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Verify current password
         if (!passwordEncoder.matches(command.currentPassword(), user.getPassword())) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/changePassword/ChangePasswordHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/changePassword/ChangePasswordHandler.java
@@ -35,8 +35,10 @@ public class ChangePasswordHandler
             return ApiResponse.validationError(e.getMessage());
         }
 
-        UserEntity user = userRepository.findById(command.userId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+        UserEntity user =
+                userRepository
+                        .findById(command.userId())
+                        .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Verify current password
         if (!passwordEncoder.matches(command.currentPassword(), user.getPassword())) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deactivateAccount/DeactivateAccountHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deactivateAccount/DeactivateAccountHandler.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.commands.deactivateAccount;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -28,11 +29,8 @@ public class DeactivateAccountHandler
             isolation = Isolation.READ_COMMITTED,
             propagation = Propagation.REQUIRED)
     public ApiResponse<Void> handle(DeactivateAccountCommand command) {
-        UserEntity user = userRepository.findById(command.userId()).orElse(null);
-
-        if (user == null) {
-            return ApiResponse.notFound(messageService.getMessage("user.not.found"));
-        }
+        UserEntity user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Log deactivation reason
         if (command.reason() != null && !command.reason().isBlank()) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deactivateAccount/DeactivateAccountHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/deactivateAccount/DeactivateAccountHandler.java
@@ -29,8 +29,10 @@ public class DeactivateAccountHandler
             isolation = Isolation.READ_COMMITTED,
             propagation = Propagation.REQUIRED)
     public ApiResponse<Void> handle(DeactivateAccountCommand command) {
-        UserEntity user = userRepository.findById(command.userId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+        UserEntity user =
+                userRepository
+                        .findById(command.userId())
+                        .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Log deactivation reason
         if (command.reason() != null && !command.reason().isBlank()) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandler.java
@@ -1,8 +1,8 @@
 package com.iyte_yazilim.proje_pazari.application.commands.promoteToProjectOwner;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -28,8 +28,10 @@ public class PromoteToProjectOwnerHandler
             isolation = Isolation.READ_COMMITTED,
             propagation = Propagation.REQUIRED)
     public ApiResponse<Void> handle(PromoteToProjectOwnerCommand command) {
-        UserEntity user = userRepository.findById(command.userId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+        UserEntity user =
+                userRepository
+                        .findById(command.userId())
+                        .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         if (user.getRole() == RoleType.PROJECT_OWNER) {
             return ApiResponse.validationError(

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandler.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.commands.promoteToProjectOwner;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
@@ -27,13 +28,8 @@ public class PromoteToProjectOwnerHandler
             isolation = Isolation.READ_COMMITTED,
             propagation = Propagation.REQUIRED)
     public ApiResponse<Void> handle(PromoteToProjectOwnerCommand command) {
-        UserEntity user = userRepository.findById(command.userId()).orElse(null);
-
-        if (user == null) {
-            return ApiResponse.notFound(
-                    messageService.getMessage(
-                            "user.not.found.with.id", new Object[] {command.userId()}));
-        }
+        UserEntity user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         if (user.getRole() == RoleType.PROJECT_OWNER) {
             return ApiResponse.validationError(

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.commands.reviewApplication;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.events.ApplicationReviewedEvent;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IValidator;
@@ -53,12 +54,8 @@ public class ReviewApplicationHandler
 
         // --- 2. Verify Application Exists ---
         ProjectApplicationEntity applicationEntity =
-                applicationRepository.findById(command.applicationId()).orElse(null);
-        if (applicationEntity == null) {
-            return ApiResponse.notFound(
-                    messageService.getMessage(
-                            "application.not.found", new Object[] {command.applicationId()}));
-        }
+                applicationRepository.findById(command.applicationId())
+                        .orElseThrow(() -> new ApplicationNotFoundException(command.applicationId()));
 
         // --- 3. Update Status ---
         applicationEntity.setStatus(command.status());

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
@@ -1,8 +1,8 @@
 package com.iyte_yazilim.proje_pazari.application.commands.reviewApplication;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.events.ApplicationReviewedEvent;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IValidator;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
@@ -54,8 +54,10 @@ public class ReviewApplicationHandler
 
         // --- 2. Verify Application Exists ---
         ProjectApplicationEntity applicationEntity =
-                applicationRepository.findById(command.applicationId())
-                        .orElseThrow(() -> new ApplicationNotFoundException(command.applicationId()));
+                applicationRepository
+                        .findById(command.applicationId())
+                        .orElseThrow(
+                                () -> new ApplicationNotFoundException(command.applicationId()));
 
         // --- 3. Update Status ---
         applicationEntity.setStatus(command.status());

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandler.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.commands.reviewFlaggedContent;
 
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FlaggedContentNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.FlaggedContentRepository;
@@ -51,11 +52,13 @@ public class ReviewFlaggedContentHandler
             case "BAN_USER":
                 flag.setStatus("REMOVED");
                 if ("USER".equals(flag.getContentType())) {
-                    UserEntity user = userRepository.findById(flag.getContentId()).orElse(null);
-                    if (user != null) {
-                        user.setIsActive(false);
-                        userRepository.save(user);
-                    }
+                    UserEntity user =
+                            userRepository
+                                    .findById(flag.getContentId())
+                                    .orElseThrow(
+                                            () -> new UserNotFoundException(flag.getContentId()));
+                    user.setIsActive(false);
+                    userRepository.save(user);
                 }
                 break;
             default:

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandler.java
@@ -1,5 +1,6 @@
 package com.iyte_yazilim.proje_pazari.application.commands.reviewFlaggedContent;
 
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FlaggedContentNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.FlaggedContentRepository;
@@ -25,10 +26,8 @@ public class ReviewFlaggedContentHandler
     @Transactional
     public ApiResponse<Void> handle(ReviewFlaggedContentCommand command) {
         FlaggedContentEntity flag =
-                flaggedContentRepository.findById(command.flagId()).orElse(null);
-        if (flag == null) {
-            return ApiResponse.notFound("Flagged content not found with id: " + command.flagId());
-        }
+                flaggedContentRepository.findById(command.flagId())
+                        .orElseThrow(() -> new FlaggedContentNotFoundException(command.flagId()));
 
         String action = command.action() != null ? command.action().toUpperCase() : "";
 

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandler.java
@@ -26,7 +26,8 @@ public class ReviewFlaggedContentHandler
     @Transactional
     public ApiResponse<Void> handle(ReviewFlaggedContentCommand command) {
         FlaggedContentEntity flag =
-                flaggedContentRepository.findById(command.flagId())
+                flaggedContentRepository
+                        .findById(command.flagId())
                         .orElseThrow(() -> new FlaggedContentNotFoundException(command.flagId()));
 
         String action = command.action() != null ? command.action().toUpperCase() : "";

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandler.java
@@ -3,6 +3,7 @@ package com.iyte_yazilim.proje_pazari.application.commands.updateUserProfile;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.application.mappers.UserDtoMapper;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -35,13 +36,8 @@ public class UpdateUserProfileHandler
             return ApiResponse.validationError(e.getMessage());
         }
 
-        UserEntity user = userRepository.findById(command.userId()).orElse(null);
-
-        if (user == null) {
-            return ApiResponse.notFound(
-                    messageService.getMessage(
-                            "user.not.found.with.id", new Object[] {command.userId()}));
-        }
+        UserEntity user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Update fields
         if (command.firstName() != null) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandler.java
@@ -36,8 +36,10 @@ public class UpdateUserProfileHandler
             return ApiResponse.validationError(e.getMessage());
         }
 
-        UserEntity user = userRepository.findById(command.userId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+        UserEntity user =
+                userRepository
+                        .findById(command.userId())
+                        .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         // Update fields
         if (command.firstName() != null) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
@@ -35,37 +35,33 @@ public class UploadProfilePictureHandler
         UserEntity user = userRepository.findById(command.userId())
                 .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
-        try {
-            // Delete old profile picture if exists
-            String oldUrl = user.getProfilePictureUrl();
-            if (oldUrl != null && !oldUrl.isBlank()) {
-                String oldPath = extractPathFromUrl(oldUrl);
-                if (oldPath != null) {
-                    try {
-                        fileStorageService.deleteFile(oldPath);
-                    } catch (FileStorageException e) {
-                        // Ignore if old file doesn't exist
-                    }
+        if (command.file() == null || command.file().isEmpty()) {
+            throw new com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException("File is required");
+        }
+
+        // Delete old profile picture if exists
+        String oldUrl = user.getProfilePictureUrl();
+        if (oldUrl != null && !oldUrl.isBlank()) {
+            String oldPath = extractPathFromUrl(oldUrl);
+            if (oldPath != null) {
+                try {
+                    fileStorageService.deleteFile(oldPath);
+                } catch (FileStorageException e) {
+                    // Ignore if old file doesn't exist
                 }
             }
-
-            // Store new file in profiles folder - returns presigned URL for MinIO
-            String storedUrl = fileStorageService.storeFile(command.file(), PROFILES_FOLDER);
-
-            // Update user profile picture URL
-            user.setProfilePictureUrl(storedUrl);
-            userRepository.save(user);
-
-            return ApiResponse.success(
-                    user.getProfilePictureUrl(),
-                    messageService.getMessage("user.profile.picture.uploaded"));
-
-        } catch (IllegalArgumentException e) {
-            return ApiResponse.validationError(e.getMessage());
-        } catch (FileStorageException e) {
-            return ApiResponse.error(
-                    messageService.getMessage("file.upload.failed", new Object[] {e.getMessage()}));
         }
+
+        // Store new file in profiles folder - returns presigned URL for MinIO
+        String storedUrl = fileStorageService.storeFile(command.file(), PROFILES_FOLDER);
+
+        // Update user profile picture URL
+        user.setProfilePictureUrl(storedUrl);
+        userRepository.save(user);
+
+        return ApiResponse.success(
+                user.getProfilePictureUrl(),
+                messageService.getMessage("user.profile.picture.uploaded"));
     }
 
     private String extractPathFromUrl(String url) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
@@ -32,11 +32,14 @@ public class UploadProfilePictureHandler
             isolation = Isolation.READ_COMMITTED,
             propagation = Propagation.REQUIRED)
     public ApiResponse<String> handle(UploadProfilePictureCommand command) {
-        UserEntity user = userRepository.findById(command.userId())
-                .orElseThrow(() -> new UserNotFoundException(command.userId()));
+        UserEntity user =
+                userRepository
+                        .findById(command.userId())
+                        .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         if (command.file() == null || command.file().isEmpty()) {
-            throw new com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException("File is required");
+            throw new com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException(
+                    "File is required");
         }
 
         // Delete old profile picture if exists

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
@@ -1,5 +1,6 @@
 package com.iyte_yazilim.proje_pazari.application.commands.uploadProfilePicture;
 
+import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
@@ -23,7 +24,7 @@ public class UploadProfilePictureHandler
 
     private final FileStorageService fileStorageService;
     private final UserRepository userRepository;
-    private final MessageService messageService; // EKLENMELI
+    private final MessageService messageService;
 
     @Override
     @Transactional(
@@ -38,8 +39,7 @@ public class UploadProfilePictureHandler
                         .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         if (command.file() == null || command.file().isEmpty()) {
-            throw new com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException(
-                    "File is required");
+            throw new ValidationException("File is required");
         }
 
         // Delete old profile picture if exists

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandler.java
@@ -3,6 +3,7 @@ package com.iyte_yazilim.proje_pazari.application.commands.uploadProfilePicture;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
@@ -31,11 +32,8 @@ public class UploadProfilePictureHandler
             isolation = Isolation.READ_COMMITTED,
             propagation = Propagation.REQUIRED)
     public ApiResponse<String> handle(UploadProfilePictureCommand command) {
-        UserEntity user = userRepository.findById(command.userId()).orElse(null);
-
-        if (user == null) {
-            return ApiResponse.notFound(messageService.getMessage("user.not.found"));
-        }
+        UserEntity user = userRepository.findById(command.userId())
+                .orElseThrow(() -> new UserNotFoundException(command.userId()));
 
         try {
             // Delete old profile picture if exists

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ApplicationNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ApplicationNotFoundException.java
@@ -1,7 +1,7 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
 public class ApplicationNotFoundException extends RuntimeException {
-  public ApplicationNotFoundException(String applicationId) {
-    super("Application not found: " + applicationId);
-  }
+    public ApplicationNotFoundException(String applicationId) {
+        super("Application not found: " + applicationId);
+    }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ApplicationNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ApplicationNotFoundException.java
@@ -1,0 +1,7 @@
+package com.iyte_yazilim.proje_pazari.domain.exceptions;
+
+public class ApplicationNotFoundException extends RuntimeException {
+  public ApplicationNotFoundException(String applicationId) {
+    super("Application not found: " + applicationId);
+  }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FlaggedContentNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FlaggedContentNotFoundException.java
@@ -1,7 +1,7 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
 public class FlaggedContentNotFoundException extends RuntimeException {
-  public FlaggedContentNotFoundException(String flagId) {
-    super("Flagged content not found: " + flagId);
-  }
+    public FlaggedContentNotFoundException(String flagId) {
+        super("Flagged content not found: " + flagId);
+    }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FlaggedContentNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FlaggedContentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.iyte_yazilim.proje_pazari.domain.exceptions;
+
+public class FlaggedContentNotFoundException extends RuntimeException {
+  public FlaggedContentNotFoundException(String flagId) {
+    super("Flagged content not found: " + flagId);
+  }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/UserNotFoundException.java
@@ -1,7 +1,7 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
 public class UserNotFoundException extends RuntimeException {
-    public UserNotFoundException(String email) {
-        super("User not found with email: " + email);
+    public UserNotFoundException(String userId) {
+        super("User not found: " + userId);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -210,14 +210,6 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 
-    @ExceptionHandler(com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleDomainValidationException(
-            com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException ex) {
-        log.warn("Domain validation error: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.validationError(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGlobalException(Exception ex) {
         log.error("Unexpected error occurred", ex);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -148,6 +148,54 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
+    @ExceptionHandler(EmailNotVerifiedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleEmailNotVerifiedException(
+            EmailNotVerifiedException ex) {
+        log.warn("Email not verified: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.forbidden(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+
+    @ExceptionHandler(EmailAlreadyVerifiedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleEmailAlreadyVerifiedException(
+            EmailAlreadyVerifiedException ex) {
+        log.warn("Email already verified: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.conflict(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+
+    @ExceptionHandler(VerificationTokenExpiredException.class)
+    public ResponseEntity<ApiResponse<Void>> handleVerificationTokenExpiredException(
+            VerificationTokenExpiredException ex) {
+        log.warn("Verification token expired: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(InvalidVerificationTokenException.class)
+    public ResponseEntity<ApiResponse<Void>> handleInvalidVerificationTokenException(
+            InvalidVerificationTokenException ex) {
+        log.warn("Invalid verification token: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(EmailSendException.class)
+    public ResponseEntity<ApiResponse<Void>> handleEmailSendException(EmailSendException ex) {
+        log.error("Email send failed: {}", ex.getMessage());
+        ApiResponse<Void> response =
+                ApiResponse.internalError(messageService.getMessage("error.internal"));
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    }
+
+    @ExceptionHandler(com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDomainValidationException(
+            com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException ex) {
+        log.warn("Domain validation error: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.validationError(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGlobalException(Exception ex) {
         log.error("Unexpected error occurred", ex);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -2,7 +2,7 @@ package com.iyte_yazilim.proje_pazari.presentation.config;
 
 import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.*;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
@@ -119,6 +119,33 @@ public class GlobalExceptionHandler {
         log.error("Illegal argument: {}", ex.getMessage());
         ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleUserNotFoundException(UserNotFoundException ex) {
+        log.warn("User not found: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(ProjectNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleProjectNotFoundException(ProjectNotFoundException ex) {
+        log.warn("Project not found: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(ApplicationNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleApplicationNotFoundException(ApplicationNotFoundException ex) {
+        log.warn("Application not found: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+    }
+
+    @ExceptionHandler(FlaggedContentNotFoundException.class)
+    public ResponseEntity<ApiResponse<Void>> handleFlaggedContentNotFoundException(FlaggedContentNotFoundException ex) {
+        log.warn("Flagged content not found: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(Exception.class)

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -2,7 +2,16 @@ package com.iyte_yazilim.proje_pazari.presentation.config;
 
 import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.*;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.EmailAlreadyVerifiedException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.EmailNotVerifiedException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.EmailSendException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FlaggedContentNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.InvalidVerificationTokenException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.VerificationTokenExpiredException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import jakarta.validation.ConstraintViolationException;
 import java.util.HashMap;
@@ -119,16 +128,16 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException.class)
     public ResponseEntity<ApiResponse<Void>> handleDomainValidationException(
             com.iyte_yazilim.proje_pazari.domain.exceptions.ValidationException ex) {
-        log.error("Validation error: {}", ex.getMessage());
+        log.warn("Domain validation error: {}", ex.getMessage());
         ApiResponse<Void> response = ApiResponse.validationError(ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 
     @ExceptionHandler(FileStorageException.class)
     public ResponseEntity<ApiResponse<Void>> handleFileStorageException(FileStorageException ex) {
-        log.debug("File storage error: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
+        log.error("File storage error: {}", ex.getMessage());
+        ApiResponse<Void> response = ApiResponse.internalError(ex.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -130,6 +130,7 @@ public class GlobalExceptionHandler {
         ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
+
     @ExceptionHandler(UserNotFoundException.class)
     public ResponseEntity<ApiResponse<Void>> handleUserNotFoundException(UserNotFoundException ex) {
         log.warn("User not found: {}", ex.getMessage());
@@ -138,21 +139,24 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(ProjectNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleProjectNotFoundException(ProjectNotFoundException ex) {
+    public ResponseEntity<ApiResponse<Void>> handleProjectNotFoundException(
+            ProjectNotFoundException ex) {
         log.warn("Project not found: {}", ex.getMessage());
         ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(ApplicationNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleApplicationNotFoundException(ApplicationNotFoundException ex) {
+    public ResponseEntity<ApiResponse<Void>> handleApplicationNotFoundException(
+            ApplicationNotFoundException ex) {
         log.warn("Application not found: {}", ex.getMessage());
         ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
     }
 
     @ExceptionHandler(FlaggedContentNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFlaggedContentNotFoundException(FlaggedContentNotFoundException ex) {
+    public ResponseEntity<ApiResponse<Void>> handleFlaggedContentNotFoundException(
+            FlaggedContentNotFoundException ex) {
         log.warn("Flagged content not found: {}", ex.getMessage());
         ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteProject/AdminDeleteProjectHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteProject/AdminDeleteProjectHandlerTest.java
@@ -1,0 +1,61 @@
+package com.iyte_yazilim.proje_pazari.application.commands.adminDeleteProject;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.github.f4b6a3.ulid.Ulid;
+import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDeleteProjectHandlerTest {
+
+    @Mock private ProjectRepository projectRepository;
+
+    @InjectMocks private AdminDeleteProjectHandler handler;
+
+    private String projectId;
+    private ProjectEntity projectEntity;
+
+    @BeforeEach
+    void setUp() {
+        projectId = Ulid.fast().toString();
+        projectEntity = new ProjectEntity();
+        projectEntity.setId(projectId);
+        projectEntity.setTitle("Test Project");
+    }
+
+    @Test
+    @DisplayName("Should delete project successfully")
+    void shouldDeleteProject_whenProjectExists() {
+        when(projectRepository.findById(projectId)).thenReturn(Optional.of(projectEntity));
+
+        ApiResponse<Void> response = handler.handle(new AdminDeleteProjectCommand(projectId));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        verify(projectRepository).delete(projectEntity);
+    }
+
+    @Test
+    @DisplayName("Should throw ProjectNotFoundException when project does not exist")
+    void shouldThrowException_whenProjectNotFound() {
+        String unknownId = Ulid.fast().toString();
+        when(projectRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+        assertThrows(
+                ProjectNotFoundException.class,
+                () -> handler.handle(new AdminDeleteProjectCommand(unknownId)));
+        verify(projectRepository, never()).delete(any());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteUser/AdminDeleteUserHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminDeleteUser/AdminDeleteUserHandlerTest.java
@@ -1,0 +1,63 @@
+package com.iyte_yazilim.proje_pazari.application.commands.adminDeleteUser;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.github.f4b6a3.ulid.Ulid;
+import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDeleteUserHandlerTest {
+
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private AdminDeleteUserHandler handler;
+
+    private String userId;
+    private UserEntity userEntity;
+
+    @BeforeEach
+    void setUp() {
+        userId = Ulid.fast().toString();
+        userEntity = new UserEntity();
+        userEntity.setId(userId);
+        userEntity.setEmail("user@std.iyte.edu.tr");
+        userEntity.setIsActive(true);
+    }
+
+    @Test
+    @DisplayName("Should deactivate user successfully")
+    void shouldDeactivateUser_whenUserExists() {
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+
+        ApiResponse<Void> response = handler.handle(new AdminDeleteUserCommand(userId));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertFalse(userEntity.getIsActive());
+        verify(userRepository).save(userEntity);
+    }
+
+    @Test
+    @DisplayName("Should throw UserNotFoundException when user does not exist")
+    void shouldThrowException_whenUserNotFound() {
+        String unknownId = Ulid.fast().toString();
+        when(userRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+        assertThrows(
+                UserNotFoundException.class,
+                () -> handler.handle(new AdminDeleteUserCommand(unknownId)));
+        verify(userRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandlerTest.java
@@ -1,0 +1,84 @@
+package com.iyte_yazilim.proje_pazari.application.commands.adminReviewApplication;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.github.f4b6a3.ulid.Ulid;
+import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
+import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectApplicationRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectApplicationEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminReviewApplicationHandlerTest {
+
+    @Mock private ProjectApplicationRepository applicationRepository;
+
+    @InjectMocks private AdminReviewApplicationHandler handler;
+
+    private String applicationId;
+    private ProjectApplicationEntity applicationEntity;
+
+    @BeforeEach
+    void setUp() {
+        applicationId = Ulid.fast().toString();
+        applicationEntity = new ProjectApplicationEntity();
+        applicationEntity.setId(applicationId);
+        applicationEntity.setStatus(ApplicationStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("Should approve application successfully")
+    void shouldApproveApplication_whenApplicationExists() {
+        when(applicationRepository.findById(applicationId))
+                .thenReturn(Optional.of(applicationEntity));
+
+        ApiResponse<Void> response =
+                handler.handle(
+                        new AdminReviewApplicationCommand(applicationId, ApplicationStatus.APPROVED));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(ApplicationStatus.APPROVED, applicationEntity.getStatus());
+        verify(applicationRepository).save(applicationEntity);
+    }
+
+    @Test
+    @DisplayName("Should reject application successfully")
+    void shouldRejectApplication_whenApplicationExists() {
+        when(applicationRepository.findById(applicationId))
+                .thenReturn(Optional.of(applicationEntity));
+
+        ApiResponse<Void> response =
+                handler.handle(
+                        new AdminReviewApplicationCommand(applicationId, ApplicationStatus.REJECTED));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(ApplicationStatus.REJECTED, applicationEntity.getStatus());
+        verify(applicationRepository).save(applicationEntity);
+    }
+
+    @Test
+    @DisplayName("Should throw ApplicationNotFoundException when application does not exist")
+    void shouldThrowException_whenApplicationNotFound() {
+        String unknownId = Ulid.fast().toString();
+        when(applicationRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+        assertThrows(
+                ApplicationNotFoundException.class,
+                () ->
+                        handler.handle(
+                                new AdminReviewApplicationCommand(
+                                        unknownId, ApplicationStatus.APPROVED)));
+        verify(applicationRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminReviewApplication/AdminReviewApplicationHandlerTest.java
@@ -45,7 +45,8 @@ class AdminReviewApplicationHandlerTest {
 
         ApiResponse<Void> response =
                 handler.handle(
-                        new AdminReviewApplicationCommand(applicationId, ApplicationStatus.APPROVED));
+                        new AdminReviewApplicationCommand(
+                                applicationId, ApplicationStatus.APPROVED));
 
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertEquals(ApplicationStatus.APPROVED, applicationEntity.getStatus());
@@ -60,7 +61,8 @@ class AdminReviewApplicationHandlerTest {
 
         ApiResponse<Void> response =
                 handler.handle(
-                        new AdminReviewApplicationCommand(applicationId, ApplicationStatus.REJECTED));
+                        new AdminReviewApplicationCommand(
+                                applicationId, ApplicationStatus.REJECTED));
 
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertEquals(ApplicationStatus.REJECTED, applicationEntity.getStatus());

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminUpdateUser/AdminUpdateUserHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/adminUpdateUser/AdminUpdateUserHandlerTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -67,16 +68,14 @@ class AdminUpdateUserHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return not found for unknown user")
-    void shouldReturnNotFoundForUnknownUser() {
+    @DisplayName("Should throw UserNotFoundException for unknown user")
+    void shouldThrowException_whenUserNotFound() {
         when(userRepository.findById("unknown")).thenReturn(Optional.empty());
 
         AdminUpdateUserCommand command =
                 new AdminUpdateUserCommand("unknown", null, null, null, null, null);
 
-        ApiResponse<Void> response = handler.handle(command);
-
-        assertNotNull(response);
+        assertThrows(UserNotFoundException.class, () -> handler.handle(command));
         verify(userRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/bulkApplicationAction/BulkApplicationActionHandlerTest.java
@@ -1,0 +1,115 @@
+package com.iyte_yazilim.proje_pazari.application.commands.bulkApplicationAction;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.github.f4b6a3.ulid.Ulid;
+import com.iyte_yazilim.proje_pazari.application.dtos.BulkActionResult;
+import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
+import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectApplicationRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectApplicationEntity;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BulkApplicationActionHandlerTest {
+
+    @Mock private ProjectApplicationRepository applicationRepository;
+
+    @InjectMocks private BulkApplicationActionHandler handler;
+
+    private String appId;
+    private ProjectApplicationEntity applicationEntity;
+
+    @BeforeEach
+    void setUp() {
+        appId = Ulid.fast().toString();
+        applicationEntity = new ProjectApplicationEntity();
+        applicationEntity.setId(appId);
+        applicationEntity.setStatus(ApplicationStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("Should approve applications in bulk")
+    void shouldApproveApplicationsInBulk() {
+        when(applicationRepository.findById(appId)).thenReturn(Optional.of(applicationEntity));
+        when(applicationRepository.save(any())).thenReturn(applicationEntity);
+
+        ApiResponse<BulkActionResult> response =
+                handler.handle(new BulkApplicationActionCommand("APPROVE", List.of(appId)));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(1, response.getData().getSuccessCount());
+        assertEquals(0, response.getData().getFailureCount());
+        assertEquals(ApplicationStatus.APPROVED, applicationEntity.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should reject applications in bulk")
+    void shouldRejectApplicationsInBulk() {
+        when(applicationRepository.findById(appId)).thenReturn(Optional.of(applicationEntity));
+        when(applicationRepository.save(any())).thenReturn(applicationEntity);
+
+        ApiResponse<BulkActionResult> response =
+                handler.handle(new BulkApplicationActionCommand("REJECT", List.of(appId)));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(1, response.getData().getSuccessCount());
+        assertEquals(ApplicationStatus.REJECTED, applicationEntity.getStatus());
+    }
+
+    @Test
+    @DisplayName("Should record failure when application is not found")
+    void shouldRecordFailure_whenApplicationNotFound() {
+        String unknownId = Ulid.fast().toString();
+        when(applicationRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+        ApiResponse<BulkActionResult> response =
+                handler.handle(new BulkApplicationActionCommand("APPROVE", List.of(unknownId)));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(0, response.getData().getSuccessCount());
+        assertEquals(1, response.getData().getFailureCount());
+    }
+
+    @Test
+    @DisplayName("Should process partial successes in bulk")
+    void shouldProcessPartialSuccess_whenSomeApplicationsNotFound() {
+        String foundId = Ulid.fast().toString();
+        String missingId = Ulid.fast().toString();
+
+        ProjectApplicationEntity foundApp = new ProjectApplicationEntity();
+        foundApp.setId(foundId);
+        foundApp.setStatus(ApplicationStatus.PENDING);
+
+        when(applicationRepository.findById(foundId)).thenReturn(Optional.of(foundApp));
+        when(applicationRepository.findById(missingId)).thenReturn(Optional.empty());
+        when(applicationRepository.save(any())).thenReturn(foundApp);
+
+        ApiResponse<BulkActionResult> response =
+                handler.handle(
+                        new BulkApplicationActionCommand("APPROVE", List.of(foundId, missingId)));
+
+        assertEquals(1, response.getData().getSuccessCount());
+        assertEquals(1, response.getData().getFailureCount());
+    }
+
+    @Test
+    @DisplayName("Should return validation error for empty list")
+    void shouldReturnValidationError_whenApplicationIdsIsEmpty() {
+        ApiResponse<BulkActionResult> response =
+                handler.handle(new BulkApplicationActionCommand("APPROVE", List.of()));
+
+        assertNotNull(response);
+        verify(applicationRepository, never()).findById(any());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/changePassword/ChangePasswordHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/changePassword/ChangePasswordHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.*;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -75,8 +76,8 @@ class ChangePasswordHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return error when user does not exist")
-    void shouldReturnError_WhenUserNotFound() {
+    @DisplayName("Should throw UserNotFoundException when user does not exist")
+    void shouldThrowException_WhenUserNotFound() {
         // Given
         String newPass = "NewPass123!";
         ChangePasswordCommand command =
@@ -84,12 +85,8 @@ class ChangePasswordHandlerTest {
 
         when(userRepository.findById("unknown-user")).thenReturn(Optional.empty());
 
-        // When
-        ApiResponse<Void> response = changePasswordHandler.handle(command);
-
-        // Then
-        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
-        assertEquals("User not found", response.getMessage());
+        // When & Then
+        assertThrows(UserNotFoundException.class, () -> changePasswordHandler.handle(command));
         verify(passwordEncoder, never()).matches(anyString(), anyString());
         verify(userRepository, never()).save(any());
     }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/deactivateAccount/DeactivateAccountHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/deactivateAccount/DeactivateAccountHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 import com.github.f4b6a3.ulid.Ulid;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -107,8 +108,8 @@ class DeactivateAccountHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return not found error when user does not exist")
-    void shouldReturnError_whenUserNotFound() {
+    @DisplayName("Should throw UserNotFoundException when user does not exist")
+    void shouldThrowException_whenUserNotFound() {
         // Given
         String nonExistentUserId = Ulid.fast().toString();
         DeactivateAccountCommand command =
@@ -116,12 +117,8 @@ class DeactivateAccountHandlerTest {
 
         when(userRepository.findById(nonExistentUserId)).thenReturn(Optional.empty());
 
-        // When
-        ApiResponse<Void> response = handler.handle(command);
-
-        // Then
-        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
-        assertEquals("User not found", response.getMessage());
+        // When & Then
+        assertThrows(UserNotFoundException.class, () -> handler.handle(command));
         verify(userRepository, never()).save(any());
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.*;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -90,22 +91,16 @@ class PromoteToProjectOwnerHandlerTest {
         }
 
         @Test
-        @DisplayName("should return NOT_FOUND when user does not exist")
-        void shouldReturnNotFoundWhenUserDoesNotExist() {
+        @DisplayName("should throw UserNotFoundException when user does not exist")
+        void shouldThrowException_whenUserDoesNotExist() {
             // Given
             String userId = "nonexistent";
             when(userRepository.findById(userId)).thenReturn(Optional.empty());
-            when(messageService.getMessage(eq("user.not.found.with.id"), any(Object[].class)))
-                    .thenReturn("User not found with id: nonexistent");
 
             PromoteToProjectOwnerCommand command = new PromoteToProjectOwnerCommand(userId);
 
-            // When
-            ApiResponse<Void> response = handler.handle(command);
-
-            // Then
-            assertEquals(ResponseCode.NOT_FOUND, response.getCode());
-            assertEquals("User not found with id: nonexistent", response.getMessage());
+            // When & Then
+            assertThrows(UserNotFoundException.class, () -> handler.handle(command));
             verify(userRepository, never()).save(any());
         }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/promoteToProjectOwner/PromoteToProjectOwnerHandlerTest.java
@@ -2,7 +2,6 @@ package com.iyte_yazilim.proje_pazari.application.commands.promoteToProjectOwner
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandlerTest.java
@@ -1,0 +1,118 @@
+package com.iyte_yazilim.proje_pazari.application.commands.reviewApplication;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.github.f4b6a3.ulid.Ulid;
+import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
+import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IValidator;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.domain.models.results.ReviewApplicationCommandResult;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectApplicationRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectApplicationEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewApplicationHandlerTest {
+
+    @Mock private ProjectApplicationRepository applicationRepository;
+    @Mock private IValidator<ReviewApplicationCommand> validator;
+    @Mock private MessageService messageService;
+    @Mock private ApplicationEventPublisher applicationEventPublisher;
+
+    @InjectMocks private ReviewApplicationHandler handler;
+
+    private String applicationId;
+    private ProjectApplicationEntity applicationEntity;
+
+    @BeforeEach
+    void setUp() {
+        applicationId = Ulid.fast().toString();
+
+        UserEntity owner = new UserEntity();
+        owner.setId(Ulid.fast().toString());
+        owner.setFirstName("Owner");
+        owner.setEmail("owner@std.iyte.edu.tr");
+
+        ProjectEntity project = new ProjectEntity();
+        project.setId(Ulid.fast().toString());
+        project.setTitle("Test Project");
+        project.setOwner(owner);
+
+        UserEntity applicant = new UserEntity();
+        applicant.setId(Ulid.fast().toString());
+        applicant.setFirstName("Applicant");
+        applicant.setEmail("applicant@std.iyte.edu.tr");
+
+        applicationEntity = new ProjectApplicationEntity();
+        applicationEntity.setId(applicationId);
+        applicationEntity.setStatus(ApplicationStatus.PENDING);
+        applicationEntity.setProject(project);
+        applicationEntity.setUser(applicant);
+
+        lenient()
+                .when(messageService.getMessage("application.reviewed.success"))
+                .thenReturn("Application reviewed successfully");
+    }
+
+    @Test
+    @DisplayName("Should approve application successfully")
+    void shouldApproveApplication_whenApplicationExists() {
+        ReviewApplicationCommand command =
+                new ReviewApplicationCommand(applicationId, ApplicationStatus.APPROVED, "Good fit");
+
+        when(validator.validate(command)).thenReturn(null);
+        when(applicationRepository.findById(applicationId))
+                .thenReturn(Optional.of(applicationEntity));
+        when(applicationRepository.save(applicationEntity)).thenReturn(applicationEntity);
+
+        ApiResponse<ReviewApplicationCommandResult> response = handler.handle(command);
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(ApplicationStatus.APPROVED, applicationEntity.getStatus());
+        verify(applicationEventPublisher).publishEvent(any(Object.class));
+    }
+
+    @Test
+    @DisplayName("Should throw ApplicationNotFoundException when application does not exist")
+    void shouldThrowException_whenApplicationNotFound() {
+        String unknownId = Ulid.fast().toString();
+        ReviewApplicationCommand command =
+                new ReviewApplicationCommand(unknownId, ApplicationStatus.APPROVED, null);
+
+        when(validator.validate(command)).thenReturn(null);
+        when(applicationRepository.findById(unknownId)).thenReturn(Optional.empty());
+
+        assertThrows(ApplicationNotFoundException.class, () -> handler.handle(command));
+        verify(applicationRepository, never()).save(any());
+        verify(applicationEventPublisher, never()).publishEvent(any(Object.class));
+    }
+
+    @Test
+    @DisplayName("Should return bad request when validation fails")
+    void shouldReturnBadRequest_whenValidationFails() {
+        ReviewApplicationCommand command =
+                new ReviewApplicationCommand(applicationId, null, null);
+
+        when(validator.validate(command)).thenReturn(new String[] {"Status is required"});
+
+        ApiResponse<ReviewApplicationCommandResult> response = handler.handle(command);
+
+        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
+        verify(applicationRepository, never()).findById(any());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandlerTest.java
@@ -105,8 +105,7 @@ class ReviewApplicationHandlerTest {
     @Test
     @DisplayName("Should return bad request when validation fails")
     void shouldReturnBadRequest_whenValidationFails() {
-        ReviewApplicationCommand command =
-                new ReviewApplicationCommand(applicationId, null, null);
+        ReviewApplicationCommand command = new ReviewApplicationCommand(applicationId, null, null);
 
         when(validator.validate(command)).thenReturn(new String[] {"Status is required"});
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandlerTest.java
@@ -83,7 +83,8 @@ class ReviewFlaggedContentHandlerTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
 
         ApiResponse<Void> response =
-                handler.handle(new ReviewFlaggedContentCommand(flagId, "BAN_USER", "Abusive behavior"));
+                handler.handle(
+                        new ReviewFlaggedContentCommand(flagId, "BAN_USER", "Abusive behavior"));
 
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertEquals("REMOVED", flagEntity.getStatus());
@@ -100,7 +101,9 @@ class ReviewFlaggedContentHandlerTest {
 
         assertThrows(
                 FlaggedContentNotFoundException.class,
-                () -> handler.handle(new ReviewFlaggedContentCommand(unknownFlagId, "APPROVE", null)));
+                () ->
+                        handler.handle(
+                                new ReviewFlaggedContentCommand(unknownFlagId, "APPROVE", null)));
         verify(flaggedContentRepository, never()).save(any());
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewFlaggedContent/ReviewFlaggedContentHandlerTest.java
@@ -1,0 +1,134 @@
+package com.iyte_yazilim.proje_pazari.application.commands.reviewFlaggedContent;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.github.f4b6a3.ulid.Ulid;
+import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FlaggedContentNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.FlaggedContentRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.FlaggedContentEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewFlaggedContentHandlerTest {
+
+    @Mock private FlaggedContentRepository flaggedContentRepository;
+    @Mock private UserRepository userRepository;
+
+    @InjectMocks private ReviewFlaggedContentHandler handler;
+
+    private String flagId;
+    private FlaggedContentEntity flagEntity;
+
+    @BeforeEach
+    void setUp() {
+        flagId = Ulid.fast().toString();
+        flagEntity = new FlaggedContentEntity();
+        flagEntity.setId(flagId);
+        flagEntity.setContentType("PROJECT");
+        flagEntity.setContentId(Ulid.fast().toString());
+        flagEntity.setStatus("PENDING");
+    }
+
+    @Test
+    @DisplayName("Should approve flagged content successfully")
+    void shouldApproveFlaggedContent_whenFlagExists() {
+        when(flaggedContentRepository.findById(flagId)).thenReturn(Optional.of(flagEntity));
+
+        ApiResponse<Void> response =
+                handler.handle(new ReviewFlaggedContentCommand(flagId, "APPROVE", "Looks fine"));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals("APPROVED", flagEntity.getStatus());
+        verify(flaggedContentRepository).save(flagEntity);
+    }
+
+    @Test
+    @DisplayName("Should remove flagged content successfully")
+    void shouldRemoveFlaggedContent_whenFlagExists() {
+        when(flaggedContentRepository.findById(flagId)).thenReturn(Optional.of(flagEntity));
+
+        ApiResponse<Void> response =
+                handler.handle(new ReviewFlaggedContentCommand(flagId, "REMOVE", "Violates rules"));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals("REMOVED", flagEntity.getStatus());
+        verify(flaggedContentRepository).save(flagEntity);
+    }
+
+    @Test
+    @DisplayName("Should ban user and remove flag when content type is USER")
+    void shouldBanUser_whenContentTypeIsUser() {
+        String userId = Ulid.fast().toString();
+        flagEntity.setContentType("USER");
+        flagEntity.setContentId(userId);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+        userEntity.setIsActive(true);
+
+        when(flaggedContentRepository.findById(flagId)).thenReturn(Optional.of(flagEntity));
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+
+        ApiResponse<Void> response =
+                handler.handle(new ReviewFlaggedContentCommand(flagId, "BAN_USER", "Abusive behavior"));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals("REMOVED", flagEntity.getStatus());
+        assertFalse(userEntity.getIsActive());
+        verify(userRepository).save(userEntity);
+        verify(flaggedContentRepository).save(flagEntity);
+    }
+
+    @Test
+    @DisplayName("Should throw FlaggedContentNotFoundException when flag does not exist")
+    void shouldThrowException_whenFlagNotFound() {
+        String unknownFlagId = Ulid.fast().toString();
+        when(flaggedContentRepository.findById(unknownFlagId)).thenReturn(Optional.empty());
+
+        assertThrows(
+                FlaggedContentNotFoundException.class,
+                () -> handler.handle(new ReviewFlaggedContentCommand(unknownFlagId, "APPROVE", null)));
+        verify(flaggedContentRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw UserNotFoundException when BAN_USER targets a non-existent user")
+    void shouldThrowException_whenBannedUserNotFound() {
+        String unknownUserId = Ulid.fast().toString();
+        flagEntity.setContentType("USER");
+        flagEntity.setContentId(unknownUserId);
+
+        when(flaggedContentRepository.findById(flagId)).thenReturn(Optional.of(flagEntity));
+        when(userRepository.findById(unknownUserId)).thenReturn(Optional.empty());
+
+        assertThrows(
+                UserNotFoundException.class,
+                () -> handler.handle(new ReviewFlaggedContentCommand(flagId, "BAN_USER", null)));
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should return validation error for unknown action")
+    void shouldReturnValidationError_whenActionIsInvalid() {
+        when(flaggedContentRepository.findById(flagId)).thenReturn(Optional.of(flagEntity));
+
+        ApiResponse<Void> response =
+                handler.handle(new ReviewFlaggedContentCommand(flagId, "UNKNOWN_ACTION", null));
+
+        assertEquals(ResponseCode.VALIDATION_ERROR, response.getCode());
+        verify(flaggedContentRepository, never()).save(any());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandlerTest.java
@@ -9,6 +9,7 @@ import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.application.mappers.UserDtoMapper;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -183,8 +184,8 @@ class UpdateUserProfileHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return not found error when user does not exist")
-    void shouldReturnError_whenUserNotFound() {
+    @DisplayName("Should throw UserNotFoundException when user does not exist")
+    void shouldThrowException_whenUserNotFound() {
         // Given
         String nonExistentUserId = Ulid.fast().toString();
         UpdateUserProfileCommand command =
@@ -193,13 +194,8 @@ class UpdateUserProfileHandlerTest {
 
         when(userRepository.findById(nonExistentUserId)).thenReturn(Optional.empty());
 
-        // When
-        ApiResponse<UserDto> response = handler.handle(command);
-
-        // Then
-        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
-        assertTrue(response.getMessage().contains("User with ID"));
-        assertTrue(response.getMessage().contains("not found"));
+        // When & Then
+        assertThrows(UserNotFoundException.class, () -> handler.handle(command));
         verify(userRepository, never()).save(any());
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
@@ -135,8 +135,11 @@ class UploadProfilePictureHandlerTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
 
         // When & Then
-        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception = 
-                assertThrows(com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException.class, () -> handler.handle(command));
+        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception =
+                assertThrows(
+                        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException
+                                .class,
+                        () -> handler.handle(command));
         assertEquals("File is required", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
@@ -155,8 +158,11 @@ class UploadProfilePictureHandlerTest {
         when(mockFile.isEmpty()).thenReturn(true);
 
         // When & Then
-        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception = 
-                assertThrows(com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException.class, () -> handler.handle(command));
+        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception =
+                assertThrows(
+                        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException
+                                .class,
+                        () -> handler.handle(command));
         assertEquals("File is required", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
@@ -177,7 +183,8 @@ class UploadProfilePictureHandlerTest {
                 .thenThrow(new IllegalArgumentException("Only image files are allowed"));
 
         // When & Then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> handler.handle(command));
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> handler.handle(command));
         assertEquals("Only image files are allowed", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
@@ -198,7 +205,8 @@ class UploadProfilePictureHandlerTest {
                 .thenThrow(new IllegalArgumentException("File size exceeds 5MB limit"));
 
         // When & Then
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> handler.handle(command));
+        IllegalArgumentException exception =
+                assertThrows(IllegalArgumentException.class, () -> handler.handle(command));
         assertEquals("File size exceeds 5MB limit", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
@@ -219,7 +227,8 @@ class UploadProfilePictureHandlerTest {
                 .thenThrow(new FileStorageException("Disk full"));
 
         // When & Then
-        FileStorageException exception = assertThrows(FileStorageException.class, () -> handler.handle(command));
+        FileStorageException exception =
+                assertThrows(FileStorageException.class, () -> handler.handle(command));
         assertEquals("Disk full", exception.getMessage());
         verify(userRepository, never()).save(any());
     }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
@@ -66,6 +66,7 @@ class UploadProfilePictureHandlerTest {
         userEntity.setProfilePictureUrl(null);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile, "profiles")).thenReturn(storedUrl);
 
         // When
@@ -93,6 +94,7 @@ class UploadProfilePictureHandlerTest {
         userEntity.setProfilePictureUrl(oldUrl);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile, "profiles")).thenReturn(newStoredUrl);
 
         // When
@@ -121,8 +123,27 @@ class UploadProfilePictureHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return validation error when file type is invalid")
-    void shouldReturnError_whenFileTypeIsInvalid() {
+    @DisplayName("Should throw ValidationException when file is null")
+    void shouldThrowException_whenFileIsNull() {
+        // Given
+        String userId = Ulid.fast().toString();
+        UploadProfilePictureCommand command = new UploadProfilePictureCommand(userId, null);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+
+        // When & Then
+        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception = 
+                assertThrows(com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException.class, () -> handler.handle(command));
+        assertEquals("File is required", exception.getMessage());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw ValidationException when file is empty")
+    void shouldThrowException_whenFileIsEmpty() {
         // Given
         String userId = Ulid.fast().toString();
         UploadProfilePictureCommand command = new UploadProfilePictureCommand(userId, mockFile);
@@ -131,21 +152,39 @@ class UploadProfilePictureHandlerTest {
         userEntity.setId(userId);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(true);
+
+        // When & Then
+        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception = 
+                assertThrows(com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException.class, () -> handler.handle(command));
+        assertEquals("File is required", exception.getMessage());
+        verify(userRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should throw IllegalArgumentException when file type is invalid")
+    void shouldThrowException_whenFileTypeIsInvalid() {
+        // Given
+        String userId = Ulid.fast().toString();
+        UploadProfilePictureCommand command = new UploadProfilePictureCommand(userId, mockFile);
+
+        UserEntity userEntity = new UserEntity();
+        userEntity.setId(userId);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile, "profiles"))
                 .thenThrow(new IllegalArgumentException("Only image files are allowed"));
 
-        // When
-        ApiResponse<String> response = handler.handle(command);
-
-        // Then
-        assertEquals(ResponseCode.VALIDATION_ERROR, response.getCode());
-        assertEquals("Only image files are allowed", response.getMessage());
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> handler.handle(command));
+        assertEquals("Only image files are allowed", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
 
     @Test
-    @DisplayName("Should return validation error when file size exceeds limit")
-    void shouldReturnError_whenFileSizeExceedsLimit() {
+    @DisplayName("Should throw IllegalArgumentException when file size exceeds limit")
+    void shouldThrowException_whenFileSizeExceedsLimit() {
         // Given
         String userId = Ulid.fast().toString();
         UploadProfilePictureCommand command = new UploadProfilePictureCommand(userId, mockFile);
@@ -154,21 +193,19 @@ class UploadProfilePictureHandlerTest {
         userEntity.setId(userId);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile, "profiles"))
                 .thenThrow(new IllegalArgumentException("File size exceeds 5MB limit"));
 
-        // When
-        ApiResponse<String> response = handler.handle(command);
-
-        // Then
-        assertEquals(ResponseCode.VALIDATION_ERROR, response.getCode());
-        assertEquals("File size exceeds 5MB limit", response.getMessage());
+        // When & Then
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> handler.handle(command));
+        assertEquals("File size exceeds 5MB limit", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
 
     @Test
-    @DisplayName("Should return error when file storage fails")
-    void shouldReturnError_whenStorageFails() {
+    @DisplayName("Should throw FileStorageException when file storage fails")
+    void shouldThrowException_whenStorageFails() {
         // Given
         String userId = Ulid.fast().toString();
         UploadProfilePictureCommand command = new UploadProfilePictureCommand(userId, mockFile);
@@ -177,16 +214,13 @@ class UploadProfilePictureHandlerTest {
         userEntity.setId(userId);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile, "profiles"))
                 .thenThrow(new FileStorageException("Disk full"));
 
-        // When
-        ApiResponse<String> response = handler.handle(command);
-
-        // Then
-        assertEquals(ResponseCode.INTERNAL_SERVER_ERROR, response.getCode());
-        assertTrue(response.getMessage().contains("Failed to upload file"));
-        assertTrue(response.getMessage().contains("Disk full"));
+        // When & Then
+        FileStorageException exception = assertThrows(FileStorageException.class, () -> handler.handle(command));
+        assertEquals("Disk full", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
 
@@ -204,6 +238,7 @@ class UploadProfilePictureHandlerTest {
         userEntity.setProfilePictureUrl(oldUrl);
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         doThrow(new FileStorageException("File not found"))
                 .when(fileStorageService)
                 .deleteFile("profiles/old-ulid.jpg");
@@ -233,6 +268,7 @@ class UploadProfilePictureHandlerTest {
         userEntity.setProfilePictureUrl("/api/v1/files/..passwd");
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile, "profiles")).thenReturn(newStoredUrl);
 
         // When
@@ -258,6 +294,7 @@ class UploadProfilePictureHandlerTest {
         userEntity.setProfilePictureUrl("   ");
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
+        when(mockFile.isEmpty()).thenReturn(false);
         when(fileStorageService.storeFile(mockFile, "profiles")).thenReturn(newStoredUrl);
 
         // When

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
@@ -11,6 +11,7 @@ import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.ApiResponse;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -105,8 +106,8 @@ class UploadProfilePictureHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return not found error when user does not exist")
-    void shouldReturnError_whenUserNotFound() {
+    @DisplayName("Should throw UserNotFoundException when user does not exist")
+    void shouldThrowException_whenUserNotFound() {
         // Given
         String nonExistentUserId = Ulid.fast().toString();
         UploadProfilePictureCommand command =
@@ -114,12 +115,8 @@ class UploadProfilePictureHandlerTest {
 
         when(userRepository.findById(nonExistentUserId)).thenReturn(Optional.empty());
 
-        // When
-        ApiResponse<String> response = handler.handle(command);
-
-        // Then
-        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
-        assertEquals("User not found", response.getMessage());
+        // When & Then
+        assertThrows(UserNotFoundException.class, () -> handler.handle(command));
         verify(userRepository, never()).save(any());
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadProfilePicture/UploadProfilePictureHandlerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.github.f4b6a3.ulid.Ulid;
+import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.ResponseCode;
@@ -135,11 +136,8 @@ class UploadProfilePictureHandlerTest {
         when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
 
         // When & Then
-        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception =
-                assertThrows(
-                        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException
-                                .class,
-                        () -> handler.handle(command));
+        ValidationException exception =
+                assertThrows(ValidationException.class, () -> handler.handle(command));
         assertEquals("File is required", exception.getMessage());
         verify(userRepository, never()).save(any());
     }
@@ -158,11 +156,8 @@ class UploadProfilePictureHandlerTest {
         when(mockFile.isEmpty()).thenReturn(true);
 
         // When & Then
-        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException exception =
-                assertThrows(
-                        com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException
-                                .class,
-                        () -> handler.handle(command));
+        ValidationException exception =
+                assertThrows(ValidationException.class, () -> handler.handle(command));
         assertEquals("File is required", exception.getMessage());
         verify(userRepository, never()).save(any());
     }


### PR DESCRIPTION
## Summary

- **Replace `orElse(null)` anti-pattern** across all 13 command handlers with `orElseThrow()` using domain exceptions (`UserNotFoundException`, `ProjectNotFoundException`, `ApplicationNotFoundException`, `FlaggedContentNotFoundException`)
- **Add missing domain exceptions**: `ApplicationNotFoundException`, `FlaggedContentNotFoundException`
- **Register all domain exceptions** in `GlobalExceptionHandler` with proper HTTP status codes (404 for not-found, 403 for email not verified, 409 for already verified, 400 for expired/invalid tokens, 500 for email send failures)
- **Fix `UserNotFoundException`** message from misleading `"User not found with email: "` to generic `"User not found: "` since all callers pass user IDs
- **Fix `FileStorageException` handler** from incorrect 404 NOT_FOUND to 500 INTERNAL_SERVER_ERROR (storage write failures like disk full are not "not found" errors)
- **Fix duplicate `handleDomainValidationException`** in `GlobalExceptionHandler` that caused compilation failure
- **Fix domain `ValidationException` handler** log level from `error` to `warn` (validation errors are not server errors)
- **Replace wildcard import** `domain.exceptions.*` with explicit imports in `GlobalExceptionHandler`
- **Replace inline fully-qualified class names** with proper imports in `BulkApplicationActionHandler` and `BulkProjectActionHandler`
- **Add 6 missing unit tests** covering exception paths: `AdminDeleteUserHandlerTest`, `AdminDeleteProjectHandlerTest`, `AdminReviewApplicationHandlerTest`, `ReviewApplicationHandlerTest`, `BulkApplicationActionHandlerTest`, `ReviewFlaggedContentHandlerTest`

## Acceptance Criteria

- [x] No handler uses `orElse(null)` followed by a null check returning `ApiResponse`
- [x] No handler returns `null`
- [x] All not-found scenarios throw a domain exception
- [x] `GlobalExceptionHandler` has `@ExceptionHandler` methods for all domain exceptions
- [x] HTTP 404 is returned for not-found resources (not 400)
- [x] Existing tests pass; new unit tests cover the exception paths
- [x] Spotless formatting passes
- [x] Full test suite passes

## Test plan

- [x] Run `./gradlew test --rerun` — all tests pass
- [x] Run `./gradlew spotlessCheck` — formatting clean
- [x] Verify each handler throws the correct domain exception when entity not found
- [x] Verify `GlobalExceptionHandler` returns 404 for all not-found exceptions
- [x] Verify `FileStorageException` returns 500 instead of 404
- [x] Verify bulk handlers collect failures via try-catch instead of propagating

Closes #65
