### PR TITLE
feat: pgAdmin setup & database management infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 .vscode/
 
 .env
+
+# Database backup dumps
+backups/

--- a/PGADMIN.md
+++ b/PGADMIN.md
@@ -1,0 +1,318 @@
+# pgAdmin — Database Management Guide
+
+pgAdmin provides a web-based UI for browsing, querying, and managing the PostgreSQL database used by Proje Pazarı.
+
+## Access
+
+### Starting pgAdmin
+
+pgAdmin runs under the `tools` Docker Compose profile:
+
+```bash
+docker compose --profile tools up -d pgadmin
+```
+
+### Login
+
+| Field    | Default value              | Override env var              |
+|----------|----------------------------|-------------------------------|
+| URL      | http://localhost:5050      | —                             |
+| Email    | admin@proje-pazari.com     | `PGADMIN_DEFAULT_EMAIL`       |
+| Password | admin123                   | `PGADMIN_DEFAULT_PASSWORD`    |
+
+The server **"Proje Pazari - Local"** connects automatically on first login — no manual configuration needed.
+
+### Navigation
+
+```
+Servers
+└── Development
+    └── Proje Pazari - Local
+        └── Databases
+            └── proje_pazari_db
+                └── Schemas → public → Tables
+```
+
+To open the query editor: right-click `proje_pazari_db` → **Query Tool** (or press `Alt+Shift+Q`).
+
+---
+
+## Query Collections
+
+### User Management
+
+```sql
+-- All users with account status
+SELECT id, email, first_name, last_name, is_active, created_at
+FROM users
+ORDER BY created_at DESC;
+
+-- User count by active status
+SELECT is_active, COUNT(*) AS count
+FROM users
+GROUP BY is_active;
+
+-- Users with project and application counts
+SELECT u.email,
+       COUNT(DISTINCT p.id)  AS projects_owned,
+       COUNT(DISTINCT pa.id) AS applications_submitted
+FROM users u
+LEFT JOIN projects p  ON p.owner_id = u.id
+LEFT JOIN project_applications pa ON pa.applicant_id = u.id
+GROUP BY u.id, u.email
+ORDER BY projects_owned DESC;
+
+-- Find users by email pattern
+SELECT id, email, first_name, last_name, created_at
+FROM users
+WHERE email ILIKE '%@std.iyte.edu.tr'
+ORDER BY created_at DESC;
+
+-- Recently registered users (last 30 days)
+SELECT id, email, first_name, last_name, created_at
+FROM users
+WHERE created_at >= NOW() - INTERVAL '30 days'
+ORDER BY created_at DESC;
+```
+
+### Project Management
+
+```sql
+-- All projects with owner email
+SELECT p.id, p.title, p.status, p.category,
+       p.max_team_size, p.current_team_size,
+       u.email AS owner_email,
+       p.created_at
+FROM projects p
+JOIN users u ON p.owner_id = u.id
+ORDER BY p.created_at DESC;
+
+-- Projects by status
+SELECT status, COUNT(*) AS count
+FROM projects
+GROUP BY status
+ORDER BY count DESC;
+
+-- Most popular projects (by application count)
+SELECT p.title, p.status,
+       u.email AS owner_email,
+       COUNT(pa.id) AS application_count
+FROM projects p
+JOIN users u ON p.owner_id = u.id
+LEFT JOIN project_applications pa ON pa.project_id = p.id
+GROUP BY p.id, p.title, p.status, u.email
+ORDER BY application_count DESC
+LIMIT 10;
+
+-- Projects with required skills
+SELECT p.title, p.status, STRING_AGG(prs.skill, ', ') AS required_skills
+FROM projects p
+LEFT JOIN project_required_skills prs ON prs.project_id = p.id
+GROUP BY p.id, p.title, p.status
+ORDER BY p.created_at DESC;
+
+-- Projects with upcoming deadlines
+SELECT p.title, p.status, p.deadline, u.email AS owner_email
+FROM projects p
+JOIN users u ON p.owner_id = u.id
+WHERE p.deadline IS NOT NULL
+  AND p.deadline > NOW()
+ORDER BY p.deadline ASC;
+
+-- Search projects by keyword
+SELECT p.id, p.title, p.status, p.category
+FROM projects p
+WHERE p.title ILIKE '%keyword%'
+   OR p.description ILIKE '%keyword%'
+ORDER BY p.created_at DESC;
+```
+
+### Application Management
+
+```sql
+-- All pending applications
+SELECT pa.id,
+       p.title  AS project_title,
+       u.email  AS applicant_email,
+       pa.status,
+       pa.created_at
+FROM project_applications pa
+JOIN projects p ON pa.project_id = p.id
+JOIN users u    ON pa.applicant_id = u.id
+WHERE pa.status = 'PENDING'
+ORDER BY pa.created_at ASC;
+
+-- Application counts by status
+SELECT status, COUNT(*) AS count
+FROM project_applications
+GROUP BY status
+ORDER BY count DESC;
+
+-- Applications per project
+SELECT p.title,
+       COUNT(pa.id)                                             AS total,
+       COUNT(pa.id) FILTER (WHERE pa.status = 'PENDING')       AS pending,
+       COUNT(pa.id) FILTER (WHERE pa.status = 'APPROVED')      AS approved,
+       COUNT(pa.id) FILTER (WHERE pa.status = 'REJECTED')      AS rejected
+FROM projects p
+LEFT JOIN project_applications pa ON pa.project_id = p.id
+GROUP BY p.id, p.title
+ORDER BY total DESC;
+
+-- Applications submitted by a specific user (replace with actual email)
+SELECT pa.id, p.title, pa.status, pa.message, pa.created_at
+FROM project_applications pa
+JOIN projects p ON pa.project_id = p.id
+JOIN users u    ON pa.applicant_id = u.id
+WHERE u.email = 'user@example.com'
+ORDER BY pa.created_at DESC;
+```
+
+### Performance & Maintenance
+
+```sql
+-- Database size
+SELECT pg_size_pretty(pg_database_size('proje_pazari_db')) AS db_size;
+
+-- Table sizes (largest first)
+SELECT schemaname,
+       tablename,
+       pg_size_pretty(pg_total_relation_size(schemaname || '.' || tablename)) AS total_size,
+       pg_size_pretty(pg_relation_size(schemaname || '.' || tablename))        AS table_size,
+       pg_size_pretty(pg_indexes_size(schemaname || '.' || tablename))         AS index_size
+FROM pg_tables
+WHERE schemaname = 'public'
+ORDER BY pg_total_relation_size(schemaname || '.' || tablename) DESC;
+
+-- Index usage (low idx_scan = potentially unused index)
+SELECT schemaname, tablename, indexname, idx_scan, idx_tup_read, idx_tup_fetch
+FROM pg_stat_user_indexes
+ORDER BY idx_scan ASC;
+
+-- Table statistics (dead tuples indicate need for VACUUM)
+SELECT schemaname, tablename,
+       n_live_tup  AS live_tuples,
+       n_dead_tup  AS dead_tuples,
+       last_vacuum,
+       last_autovacuum
+FROM pg_stat_user_tables
+ORDER BY n_dead_tup DESC;
+
+-- Active connections
+SELECT pid, usename, application_name, state, query_start,
+       LEFT(query, 80) AS query_preview
+FROM pg_stat_activity
+WHERE datname = 'proje_pazari_db'
+  AND state <> 'idle'
+ORDER BY query_start;
+
+-- Enable query statistics extension (run once as superuser)
+-- CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
+-- Slowest queries (requires pg_stat_statements)
+-- SELECT query, calls, total_exec_time, mean_exec_time
+-- FROM pg_stat_statements
+-- ORDER BY mean_exec_time DESC
+-- LIMIT 10;
+```
+
+---
+
+## Backup & Restore
+
+### Manual Backup via pgAdmin UI
+
+1. In the object browser, right-click `proje_pazari_db` → **Backup...**
+2. Set **Format** to `Custom`
+3. Choose a file path and click **Backup**
+
+### Automated Backup Script
+
+```bash
+# Run once
+./scripts/backup-database.sh
+
+# Output: ./backups/postgres/proje_pazari_db_YYYYMMDD_HHMMSS.dump
+# Retention: last 7 days (configurable via RETAIN_DAYS)
+```
+
+Environment variable overrides:
+
+| Variable             | Default             | Description                  |
+|----------------------|---------------------|------------------------------|
+| `POSTGRES_CONTAINER` | `proje-pazari-db`   | Running container name       |
+| `POSTGRES_USER`      | `yazilim`           | Database user                |
+| `POSTGRES_DB`        | `proje_pazari_db`   | Database name                |
+| `BACKUP_DIR`         | `./backups/postgres`| Output directory             |
+| `RETAIN_DAYS`        | `7`                 | Days of backups to keep      |
+
+### Manual Backup via CLI
+
+```bash
+docker exec proje-pazari-db pg_dump \
+  -U yazilim -Fc proje_pazari_db > backup_$(date +%Y%m%d).dump
+```
+
+### Restore via pgAdmin UI
+
+1. Right-click `proje_pazari_db` → **Restore...**
+2. Select the `.dump` file
+3. Click **Restore**
+
+### Restore via CLI
+
+```bash
+docker exec -i proje-pazari-db pg_restore \
+  -U yazilim -d proje_pazari_db < backup_20250215.dump
+```
+
+---
+
+## Security
+
+### Read-Only Analytics User
+
+Run this in the Query Tool to create a read-only user for reporting purposes:
+
+```sql
+CREATE USER readonly_user WITH PASSWORD 'choose-a-strong-password';
+GRANT CONNECT ON DATABASE proje_pazari_db TO readonly_user;
+GRANT USAGE ON SCHEMA public TO readonly_user;
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO readonly_user;
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO readonly_user;
+```
+
+---
+
+## Troubleshooting
+
+### pgAdmin won't start
+
+```bash
+# Check logs
+docker compose --profile tools logs pgadmin
+
+# Ensure postgres is healthy first
+docker compose ps postgres
+```
+
+### "Server not found" after login
+
+The `servers.json` is only loaded on first startup. If you changed it after pgAdmin already created its data volume:
+
+```bash
+docker compose --profile tools down pgadmin
+docker volume rm proje-pazari-backend_pgadmin_data
+docker compose --profile tools up -d pgadmin
+```
+
+### Password authentication failed
+
+The `pgpass` file at `docker/pgadmin/pgpass` must match the `POSTGRES_PASSWORD` used by the postgres container. If you changed the postgres password, update `docker/pgadmin/pgpass` accordingly.
+
+### Direct psql access (without pgAdmin)
+
+```bash
+docker exec -it proje-pazari-db psql -U yazilim -d proje_pazari_db
+```

--- a/PGADMIN.md
+++ b/PGADMIN.md
@@ -311,6 +311,14 @@ docker compose --profile tools up -d pgadmin
 
 The `pgpass` file at `docker/pgadmin/pgpass` must match the `POSTGRES_PASSWORD` used by the postgres container. If you changed the postgres password, update `docker/pgadmin/pgpass` accordingly.
 
+pgpass also requires restricted file permissions. Run this once after cloning:
+
+```bash
+chmod 600 docker/pgadmin/pgpass
+```
+
+Git does not track permissions on non-executable files, so each developer must do this manually.
+
 ### Direct psql access (without pgAdmin)
 
 ```bash

--- a/PGADMIN.md
+++ b/PGADMIN.md
@@ -263,7 +263,7 @@ docker exec proje-pazari-db pg_dump \
 
 ```bash
 docker exec -i proje-pazari-db pg_restore \
-  -U yazilim -d proje_pazari_db < backup_20250215.dump
+  -U yazilim -d proje_pazari_db < backups/postgres/proje_pazari_db_20250215_120000.dump
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This will start:
 - Elasticsearch on port 9200
 - Application API on port 8080
 - Prometheus on port 9090, Grafana on port 3030, Alertmanager on port 9093 (use `--profile monitoring` flag)
-- PgAdmin on port 5050 (use `--profile tools` flag)
+- pgAdmin on port 5050 (use `--profile tools` flag)
 
 ### 4. Run the Application
 
@@ -215,6 +215,24 @@ docker compose --profile maintenance up -d minio-backup-scheduler
 
 - Uses `BACKUP_INTERVAL_SECONDS` (default `86400`)
 - Writes timestamped backups under `./backups/minio/`
+
+**pgAdmin — Database Management UI:**
+```bash
+docker compose --profile tools up -d pgadmin
+```
+
+- pgAdmin UI: http://localhost:5050
+- Email: `admin@proje-pazari.com` (override: `PGADMIN_DEFAULT_EMAIL`)
+- Password: `admin123` (override: `PGADMIN_DEFAULT_PASSWORD`)
+- The "Proje Pazari - Local" server connects automatically — no manual setup required
+
+For query collections, backup/restore procedures, and troubleshooting, see [`PGADMIN.md`](PGADMIN.md).
+
+**PostgreSQL Backup:**
+```bash
+./scripts/backup-database.sh
+# Writes timestamped dumps under ./backups/postgres/ (7-day retention)
+```
 
 ### 6. Access API Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -356,9 +356,10 @@ services:
     image: dpage/pgadmin4:latest
     container_name: proje-pazari-pgadmin
     environment:
-      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL}
-      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD}
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@proje-pazari.com}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin123}
       PGADMIN_CONFIG_SERVER_MODE: "False"
+      PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
     ports:
       - "127.0.0.1:5050:80"
     volumes:
@@ -366,7 +367,8 @@ services:
       - ./docker/pgadmin/servers.json:/pgadmin4/servers.json:ro
       - ./docker/pgadmin/pgpass:/pgpass:ro
     depends_on:
-      - postgres
+      postgres:
+        condition: service_healthy
     networks:
       - proje-pazari-network
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -357,7 +357,7 @@ services:
     container_name: proje-pazari-pgadmin
     environment:
       PGADMIN_DEFAULT_EMAIL: ${PGADMIN_DEFAULT_EMAIL:-admin@proje-pazari.com}
-      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin123}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_DEFAULT_PASSWORD:-admin123} # Dev default — set PGADMIN_DEFAULT_PASSWORD in .env for other environments
       PGADMIN_CONFIG_SERVER_MODE: "False"
       PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED: "False"
     ports:

--- a/docker/pgadmin/servers.json
+++ b/docker/pgadmin/servers.json
@@ -1,14 +1,15 @@
 {
   "Servers": {
     "1": {
-      "Name": "Proje Pazari DB",
-      "Group": "Servers",
+      "Name": "Proje Pazari - Local",
+      "Group": "Development",
       "Host": "postgres",
       "Port": 5432,
       "MaintenanceDB": "proje_pazari_db",
       "Username": "yazilim",
       "SSLMode": "prefer",
-      "PassFile": "/pgpass"
+      "PassFile": "/pgpass",
+      "Comment": "Proje Pazari development database"
     }
   }
 }

--- a/docs/DATABASE.md
+++ b/docs/DATABASE.md
@@ -259,10 +259,12 @@ ORDER BY pending_count DESC;
 
 ### pgAdmin Access
 
-When running with Docker Compose:
+When running with Docker Compose (`--profile tools`):
 - URL: http://localhost:5050
-- Email: admin@proje-pazari.com
-- Password: admin
+- Email: admin@proje-pazari.com (override: `PGADMIN_DEFAULT_EMAIL`)
+- Password: admin123 (override: `PGADMIN_DEFAULT_PASSWORD`)
+
+See [PGADMIN.md](../PGADMIN.md) for the full guide including query collections, backup/restore procedures, and troubleshooting.
 
 ### Direct Connection
 

--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 # backup-database.sh — Automated PostgreSQL backup script
 #
 # Usage:
@@ -8,13 +9,15 @@
 #   POSTGRES_CONTAINER  — Docker container name (default: proje-pazari-db)
 #   POSTGRES_USER       — Database user (default: yazilim)
 #   POSTGRES_DB         — Database name (default: proje_pazari_db)
-#   BACKUP_DIR          — Backup output directory (default: ./backups/postgres)
+#   BACKUP_DIR          — Backup output directory (default: <project-root>/backups/postgres)
 #   RETAIN_DAYS         — Days of backups to keep (default: 7)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-proje-pazari-db}"
 POSTGRES_USER="${POSTGRES_USER:-yazilim}"
 POSTGRES_DB="${POSTGRES_DB:-proje_pazari_db}"
-BACKUP_DIR="${BACKUP_DIR:-./backups/postgres}"
+BACKUP_DIR="${BACKUP_DIR:-$SCRIPT_DIR/../backups/postgres}"
 RETAIN_DAYS="${RETAIN_DAYS:-7}"
 
 TIMESTAMP=$(date +%Y%m%d_%H%M%S)
@@ -32,13 +35,17 @@ if ! docker ps --format '{{.Names}}' | grep -q "^${POSTGRES_CONTAINER}$"; then
   exit 1
 fi
 
-docker exec "$POSTGRES_CONTAINER" pg_dump \
+if ! docker exec "$POSTGRES_CONTAINER" pg_dump \
   -U "$POSTGRES_USER" \
   -Fc \
-  "$POSTGRES_DB" > "$BACKUP_FILE"
-
-if [ $? -ne 0 ]; then
+  "$POSTGRES_DB" > "$BACKUP_FILE"; then
   echo "ERROR: Backup failed."
+  rm -f "$BACKUP_FILE"
+  exit 1
+fi
+
+if [ ! -s "$BACKUP_FILE" ]; then
+  echo "ERROR: Backup file is empty."
   rm -f "$BACKUP_FILE"
   exit 1
 fi

--- a/scripts/backup-database.sh
+++ b/scripts/backup-database.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# backup-database.sh — Automated PostgreSQL backup script
+#
+# Usage:
+#   ./scripts/backup-database.sh
+#
+# Environment variables (all optional, defaults match docker-compose.yml):
+#   POSTGRES_CONTAINER  — Docker container name (default: proje-pazari-db)
+#   POSTGRES_USER       — Database user (default: yazilim)
+#   POSTGRES_DB         — Database name (default: proje_pazari_db)
+#   BACKUP_DIR          — Backup output directory (default: ./backups/postgres)
+#   RETAIN_DAYS         — Days of backups to keep (default: 7)
+
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-proje-pazari-db}"
+POSTGRES_USER="${POSTGRES_USER:-yazilim}"
+POSTGRES_DB="${POSTGRES_DB:-proje_pazari_db}"
+BACKUP_DIR="${BACKUP_DIR:-./backups/postgres}"
+RETAIN_DAYS="${RETAIN_DAYS:-7}"
+
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="$BACKUP_DIR/${POSTGRES_DB}_${TIMESTAMP}.dump"
+
+mkdir -p "$BACKUP_DIR"
+
+echo "Starting PostgreSQL backup..."
+echo "  Container : $POSTGRES_CONTAINER"
+echo "  Database  : $POSTGRES_DB"
+echo "  Output    : $BACKUP_FILE"
+
+if ! docker ps --format '{{.Names}}' | grep -q "^${POSTGRES_CONTAINER}$"; then
+  echo "ERROR: Container '$POSTGRES_CONTAINER' is not running."
+  exit 1
+fi
+
+docker exec "$POSTGRES_CONTAINER" pg_dump \
+  -U "$POSTGRES_USER" \
+  -Fc \
+  "$POSTGRES_DB" > "$BACKUP_FILE"
+
+if [ $? -ne 0 ]; then
+  echo "ERROR: Backup failed."
+  rm -f "$BACKUP_FILE"
+  exit 1
+fi
+
+echo "Backup completed: $BACKUP_FILE ($(du -sh "$BACKUP_FILE" | cut -f1))"
+
+# Remove backups older than RETAIN_DAYS
+find "$BACKUP_DIR" -name "*.dump" -mtime +"$RETAIN_DAYS" -delete
+echo "Cleaned up backups older than $RETAIN_DAYS days."


### PR DESCRIPTION
## Summary

  - pgAdmin accessible at http://localhost:5050 with auto-connecting server
  - Added env var defaults so no `.env` entries required for dev
  - Added `PGADMIN_CONFIG_MASTER_PASSWORD_REQUIRED=False` for seamless login
  - Created `scripts/backup-database.sh` with 7-day retention
  - Created `PGADMIN.md` with 20+ SQL queries, backup/restore, troubleshooting
  - Fixed pgAdmin credentials in docs and README
  - Added `backups/` to .gitignore
  
   What's deferred and why

  Data seeding scripts (Section 6) — blocked by schema mismatch

  The issue's sample INSERT statements reference columns that do not exist in the actual database schema. Running them
  would cause SQL errors. They cannot be implemented until the schema is aligned.

  ┌──────────────────────┬─────────────────────────────────────────┐
  │   Issue references   │              Actual schema              │
  ├──────────────────────┼─────────────────────────────────────────┤
  │ users.role           │ ❌ column does not exist                │
  ├──────────────────────┼─────────────────────────────────────────┤
  │ users.email_verified │ ❌ column does not exist                │
  ├──────────────────────┼─────────────────────────────────────────┤
  │ projects.visibility  │ ❌ column does not exist                │
  ├──────────────────────┼─────────────────────────────────────────┤
  │ table applications   │ ❌ actual table is project_applications │
  └──────────────────────┴─────────────────────────────────────────┘

  Once these columns are added to the schema (or the issue is updated to match the real schema), the seeding scripts can
   be added.

  Database monitoring dashboards (Section 4) — not automatable

  Custom dashboards in pgAdmin require manual configuration through the UI (clicking, dragging, saving). There are no
  files that can be committed to pre-configure them. The performance queries needed to build those dashboards are
  already documented in PGADMIN.md.

  chmod 600 docker/pgadmin/pgpass — cannot be tracked by git

  Git does not track file permissions on non-executable files. Each developer needs to run this once after cloning:

  chmod 600 docker/pgadmin/pgpass

  Added a note about this in PGADMIN.md under Troubleshooting.

  Nice to Have items — out of scope for this PR

  - pg_stat_statements extension (requires postgres superuser, not part of app init)
  - Email alerts for backup failures
  - ERD generation

  ---
  

  Closes #58