### PR TITLE
Fix registration verification response code collision

### DIFF
--- a/MONITORING.md
+++ b/MONITORING.md
@@ -213,7 +213,7 @@ Source  : RegisterUserHandler.handle()
 
 | Event | When incremented |
 |---|---|
-| `status=success` | User saved, verification email sent, `ApiResponse.created()` returned |
+| `status=success` | User saved, verification email sent, `ApiResponse.registeredNeedsVerification()` returned |
 | `status=failure` | Validation error, invalid IYTE email, duplicate email |
 
 **Example PromQL:**

--- a/docs/API.md
+++ b/docs/API.md
@@ -39,10 +39,10 @@ POST /auth/register
 }
 ```
 
-**Success Response (201 Created):**
+**Success Response (201 Created - Email Verification Required):**
 ```json
 {
-  "code": "CREATED",
+  "code": 11,
   "message": "User registered successfully",
   "data": {
     "userId": "01HQXV5KXBW9FYMN8CJZSP2R4G",
@@ -463,6 +463,7 @@ GET /health
 |------|-------------|-------------|
 | `SUCCESS` | 200 | Request completed successfully |
 | `CREATED` | 201 | Resource created successfully |
+| `REGISTERED_NEEDS_VERIFICATION` | 201 | User registered and email verification is required |
 | `BAD_REQUEST` | 400 | Invalid request data |
 | `UNAUTHORIZED` | 401 | Authentication required |
 | `FORBIDDEN` | 403 | Insufficient permissions |

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/registerUser/RegisterUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/registerUser/RegisterUserHandler.java
@@ -104,6 +104,7 @@ public class RegisterUserHandler
 
         // --- 11. Response with localized message ---
         metricsService.incrementUserRegistrationSuccess();
-        return ApiResponse.created(result, messageService.getMessage("user.registered.success"));
+        return ApiResponse.registeredNeedsVerification(
+                result, messageService.getMessage("user.registered.success"));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ApiResponse.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ApiResponse.java
@@ -42,6 +42,10 @@ public class ApiResponse<T> {
         return new ApiResponse<>(data, message, ResponseCode.ACCEPTED);
     }
 
+    public static <T> ApiResponse<T> registeredNeedsVerification(T data, String message) {
+        return new ApiResponse<>(data, message, ResponseCode.REGISTERED_NEEDS_VERIFICATION);
+    }
+
     // --- ERROR RESPONSES ---
 
     public static <T> ApiResponse<T> badRequest(String message) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ResponseCode.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ResponseCode.java
@@ -14,9 +14,10 @@ import lombok.Getter;
  * <h2>Code Categories:</h2>
  *
  * <ul>
- *   <li><b>0-3:</b> Success codes
+ *   <li><b>0-3:</b> General success codes
  *   <li><b>4-9:</b> Client error codes
- *   <li><b>10+:</b> Server error codes
+ *   <li><b>10:</b> Server error code
+ *   <li><b>11+:</b> Application flow success states
  * </ul>
  *
  * @author IYTE Yazılım Topluluğu
@@ -40,6 +41,9 @@ public enum ResponseCode {
 
     /** Request was accepted for processing. */
     ACCEPTED(3),
+
+    /** User registered successfully and must verify their email address. */
+    REGISTERED_NEEDS_VERIFICATION(11),
 
     // Client error codes
     /** Request was malformed or invalid. */

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
@@ -103,7 +103,8 @@ public class AuthController extends BaseController {
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "201",
-                        description = "User registered successfully",
+                        description =
+                                "User registered successfully and email verification is required",
                         content =
                                 @Content(
                                         mediaType = MediaType.APPLICATION_JSON_VALUE,
@@ -114,7 +115,7 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "CREATED",
+                                            "code": 11,
                                             "message": "User registered successfully",
                                             "data": {
                                                 "userId": "01HQXV5KXBW9FYMN8CJZSP2R4G",

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/BaseController.java
@@ -28,6 +28,7 @@ public abstract class BaseController {
         return switch (code) {
             case SUCCESS -> HttpStatus.OK;
             case CREATED -> HttpStatus.CREATED;
+            case REGISTERED_NEEDS_VERIFICATION -> HttpStatus.CREATED;
             case ACCEPTED -> HttpStatus.ACCEPTED;
             case NO_CONTENT -> HttpStatus.NO_CONTENT;
             case BAD_REQUEST -> HttpStatus.BAD_REQUEST;

--- a/src/test/java/ApiResponseSerializationTest.java
+++ b/src/test/java/ApiResponseSerializationTest.java
@@ -1,7 +1,10 @@
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.iyte_yazilim.proje_pazari.application.common.ResponseCode;
+import java.util.HashSet;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 
 public class ApiResponseSerializationTest {
@@ -18,5 +21,28 @@ public class ApiResponseSerializationTest {
     void shouldDeserializeIntegerToEnum() throws Exception {
         ResponseCode code = om.readValue("0", ResponseCode.class);
         assertEquals(ResponseCode.SUCCESS, code);
+    }
+
+    @Test
+    void shouldSerializeRegisteredNeedsVerificationAsInteger() throws Exception {
+        String json = om.writeValueAsString(ResponseCode.REGISTERED_NEEDS_VERIFICATION);
+        assertEquals("11", json);
+    }
+
+    @Test
+    void shouldDeserializeRegisteredNeedsVerificationIntegerToEnum() throws Exception {
+        ResponseCode code = om.readValue("11", ResponseCode.class);
+        assertEquals(ResponseCode.REGISTERED_NEEDS_VERIFICATION, code);
+    }
+
+    @Test
+    void shouldHaveUniqueNumericStatuses() {
+        Set<Integer> statuses = new HashSet<>();
+
+        for (ResponseCode code : ResponseCode.values()) {
+            assertTrue(
+                    statuses.add(code.getStatus()),
+                    () -> "Duplicate numeric response status: " + code.getStatus());
+        }
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/RegisterUserHandlerTransactionTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/RegisterUserHandlerTransactionTest.java
@@ -32,7 +32,7 @@ class RegisterUserHandlerTransactionTest {
 
         // First registration should succeed
         ApiResponse<RegisterUserResult> firstResponse = handler.handle(command);
-        assertEquals(ResponseCode.CREATED, firstResponse.getCode());
+        assertEquals(ResponseCode.REGISTERED_NEEDS_VERIFICATION, firstResponse.getCode());
 
         // When - try to register with same email (should fail due to unique constraint)
         RegisterUserCommand duplicateCommand =
@@ -58,7 +58,7 @@ class RegisterUserHandlerTransactionTest {
 
         // Then
         assertNotNull(response);
-        assertEquals(ResponseCode.CREATED, response.getCode());
+        assertEquals(ResponseCode.REGISTERED_NEEDS_VERIFICATION, response.getCode());
         assertTrue(userRepository.existsByEmail(email), "User was not persisted to the database!");
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/registerUser/RegisterUserHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/registerUser/RegisterUserHandlerTest.java
@@ -106,11 +106,12 @@ class RegisterUserHandlerTest {
         ApiResponse<RegisterUserResult> response = handler.handle(command);
 
         // Then
-        assertEquals(ResponseCode.CREATED, response.getCode());
+        assertEquals(ResponseCode.REGISTERED_NEEDS_VERIFICATION, response.getCode());
         assertNotNull(response.getData());
         assertEquals(expectedResult.userId(), response.getData().userId());
         assertEquals(expectedResult.email(), response.getData().email());
         verify(userRepository).save(userEntity);
+        verify(emailVerificationRepository).save(any());
         verify(passwordEncoder).encode(command.password());
         verify(metricsService).incrementUserRegistrationSuccess();
     }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/common/ApiResponseTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/common/ApiResponseTest.java
@@ -46,6 +46,19 @@ class ApiResponseTest {
     }
 
     @Test
+    @DisplayName("Should create registered needs verification response")
+    void shouldCreateRegisteredNeedsVerificationResponse() {
+        // When
+        ApiResponse<String> response =
+                ApiResponse.registeredNeedsVerification("new-user", "Verify your email");
+
+        // Then
+        assertEquals(ResponseCode.REGISTERED_NEEDS_VERIFICATION, response.getCode());
+        assertEquals("new-user", response.getData());
+        assertEquals("Verify your email", response.getMessage());
+    }
+
+    @Test
     @DisplayName("Should create bad request response without data")
     void shouldCreateBadRequestResponse() {
         // When

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthControllerIntegrationTest.java
@@ -79,6 +79,7 @@ class AuthControllerIntegrationTest extends IntegrationTestBase {
         void register_validData_returns201() throws Exception {
             registerUser(VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME)
                     .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.code").value(11))
                     .andExpect(jsonPath("$.data.userId").isNotEmpty())
                     .andExpect(jsonPath("$.data.email").value(VALID_EMAIL))
                     .andExpect(jsonPath("$.data.firstName").value(VALID_FIRST_NAME))

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ErrorHandlingIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ErrorHandlingIntegrationTest.java
@@ -84,7 +84,7 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
                                                             VALID_FIRST_NAME,
                                                             VALID_LAST_NAME))))
                     .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.code").value(2))
+                    .andExpect(jsonPath("$.code").value(11))
                     .andExpect(jsonPath("$.data").exists())
                     .andExpect(jsonPath("$.message").exists())
                     .andExpect(jsonPath("$.timestamp").exists());
@@ -353,8 +353,8 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
     class ResponseCodeMappingTests {
 
         @Test
-        @DisplayName("1. SUCCESS code is 2")
-        void successCode_is0() throws Exception {
+        @DisplayName("1. Registered needs verification code is 11")
+        void registeredNeedsVerificationCode_is11() throws Exception {
             mockMvc.perform(
                             post("/api/v1/auth/register")
                                     .contentType(MediaType.APPLICATION_JSON)
@@ -366,7 +366,7 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
                                                             VALID_FIRST_NAME,
                                                             VALID_LAST_NAME))))
                     .andExpect(status().isCreated())
-                    .andExpect(jsonPath("$.code").value(2));
+                    .andExpect(jsonPath("$.code").value(11));
         }
 
         @Test


### PR DESCRIPTION
## Summary
- Fixes #135 by adding `REGISTERED_NEEDS_VERIFICATION = 11` for successful registrations that require email verification.
- Keeps `CREATED = 2` unchanged for normal create operations.
- Maps the new registration flow code to HTTP `201 Created` and updates Swagger/API/monitoring docs.

## Validation
- `./gradlew test --tests ApiResponseSerializationTest --tests com.iyte_yazilim.proje_pazari.application.common.ApiResponseTest --tests com.iyte_yazilim.proje_pazari.application.commands.registerUser.RegisterUserHandlerTest --tests com.iyte_yazilim.proje_pazari.application.RegisterUserHandlerTransactionTest --tests com.iyte_yazilim.proje_pazari.presentation.controllers.AuthControllerIntegrationTest --tests com.iyte_yazilim.proje_pazari.presentation.controllers.ErrorHandlingIntegrationTest`
- `./gradlew test --tests com.iyte_yazilim.proje_pazari.presentation.controllers.ErrorHandlingIntegrationTest`
- `./gradlew spotlessCheck`

## Frontend Coordination
- Companion frontend PR updates the client response code enum and success-code whitelist for code `11`.
