### PR TITLE
fix: persist application review messages

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
@@ -96,14 +96,15 @@ public class ReviewApplicationHandler
             }
 
             // --- 3b. Approve via domain aggregate (enforces PENDING guard) ---
-            application.approve();
+            application.approve(command.reviewMessage());
         } else {
             // --- 3c. Reject via domain aggregate (enforces PENDING guard) ---
-            application.reject();
+            application.reject(command.reviewMessage());
         }
 
-        // --- 4. Sync status back to persistence entity ---
+        // --- 4. Sync review result back to persistence entity ---
         applicationEntity.setStatus(application.getStatus());
+        applicationEntity.setReviewMessage(application.getReviewMessage());
 
         // --- 5. Persistence ---
         ProjectApplicationEntity savedApplication = applicationRepository.save(applicationEntity);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/dtos/ApplicationDto.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/dtos/ApplicationDto.java
@@ -13,4 +13,5 @@ public record ApplicationDto(
         @Schema(description = "Applicant name") String applicantName,
         @Schema(description = "Applicant email") String applicantEmail,
         @Schema(description = "Application status") ApplicationStatus status,
+        @Schema(description = "Review message provided by the project owner") String reviewMessage,
         @Schema(description = "Submission date") LocalDateTime createdAt) {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectApplications/GetProjectApplicationsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectApplications/GetProjectApplicationsHandler.java
@@ -73,6 +73,7 @@ public class GetProjectApplicationsHandler
                 applicantName,
                 entity.getUser().getEmail(),
                 entity.getStatus(),
+                entity.getReviewMessage(),
                 entity.getCreatedAt());
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUserApplications/GetUserApplicationsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUserApplications/GetUserApplicationsHandler.java
@@ -73,6 +73,7 @@ public class GetUserApplicationsHandler
                 applicantName,
                 entity.getUser().getEmail(),
                 entity.getStatus(),
+                entity.getReviewMessage(),
                 entity.getCreatedAt());
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/entities/ProjectApplication.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/entities/ProjectApplication.java
@@ -53,6 +53,9 @@ public class ProjectApplication extends BaseEntity<Ulid> {
     /** The current status of the application. Defaults to PENDING. */
     private ApplicationStatus status = ApplicationStatus.PENDING;
 
+    /** Optional message provided by the project owner during approval or rejection. */
+    private String reviewMessage;
+
     /**
      * Creates a new application for the given project and user.
      *
@@ -78,8 +81,19 @@ public class ProjectApplication extends BaseEntity<Ulid> {
      *     ApplicationStatus#PENDING}
      */
     public void approve() {
+        approve(null);
+    }
+
+    /**
+     * Approves this application and stores the owner's review message.
+     *
+     * @throws IllegalApplicationStateException if the current status is not {@link
+     *     ApplicationStatus#PENDING}
+     */
+    public void approve(String reviewMessage) {
         requirePending("approve");
         this.status = ApplicationStatus.APPROVED;
+        this.reviewMessage = reviewMessage;
     }
 
     /**
@@ -89,8 +103,19 @@ public class ProjectApplication extends BaseEntity<Ulid> {
      *     ApplicationStatus#PENDING}
      */
     public void reject() {
+        reject(null);
+    }
+
+    /**
+     * Rejects this application and stores the owner's review message.
+     *
+     * @throws IllegalApplicationStateException if the current status is not {@link
+     *     ApplicationStatus#PENDING}
+     */
+    public void reject(String reviewMessage) {
         requirePending("reject");
         this.status = ApplicationStatus.REJECTED;
+        this.reviewMessage = reviewMessage;
     }
 
     /**
@@ -118,9 +143,25 @@ public class ProjectApplication extends BaseEntity<Ulid> {
      * @param status the persisted status
      */
     public void reconstitute(Project project, User user, ApplicationStatus status) {
+        reconstitute(project, user, status, null);
+    }
+
+    /**
+     * Reconstitutes the application state from persistence without triggering guards.
+     *
+     * <p><strong>Infrastructure-only</strong> — must not be called from domain or application code.
+     *
+     * @param project the project
+     * @param user the applicant
+     * @param status the persisted status
+     * @param reviewMessage the persisted review message
+     */
+    public void reconstitute(
+            Project project, User user, ApplicationStatus status, String reviewMessage) {
         this.project = project;
         this.user = user;
         this.status = status;
+        this.reviewMessage = reviewMessage;
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/ProjectApplicationMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/ProjectApplicationMapper.java
@@ -35,6 +35,7 @@ public interface ProjectApplicationMapper {
     @Mapping(target = "project", ignore = true) // Avoid circular mapping
     @Mapping(target = "user", ignore = true)
     @Mapping(target = "status", ignore = true)
+    @Mapping(target = "reviewMessage", ignore = true)
     ProjectApplication entityToDomainBase(ProjectApplicationEntity projectApplicationEntity);
 
     /**
@@ -47,7 +48,7 @@ public interface ProjectApplicationMapper {
         }
         ProjectApplication domain = entityToDomainBase(entity);
         // Use reconstitute to bypass domain guards — this is infrastructure mapping
-        domain.reconstitute(null, null, entity.getStatus());
+        domain.reconstitute(null, null, entity.getStatus(), entity.getReviewMessage());
         return domain;
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/ProjectApplicationEntity.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/ProjectApplicationEntity.java
@@ -48,6 +48,9 @@ public class ProjectApplicationEntity {
     @Column(name = "status", nullable = false)
     private ApplicationStatus status = ApplicationStatus.PENDING;
 
+    @Column(name = "review_message", columnDefinition = "TEXT")
+    private String reviewMessage;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/src/main/resources/db/migration/V3__add_review_message_to_project_applications.sql
+++ b/src/main/resources/db/migration/V3__add_review_message_to_project_applications.sql
@@ -1,0 +1,3 @@
+-- Migration: Persist owner review messages for project applications
+-- Required for environments with spring.jpa.hibernate.ddl-auto=validate (staging, production)
+ALTER TABLE project_applications ADD COLUMN IF NOT EXISTS review_message TEXT;

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandlerTest.java
@@ -104,10 +104,34 @@ class ReviewApplicationHandlerTest {
 
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertEquals(ApplicationStatus.APPROVED, applicationEntity.getStatus());
+        assertEquals("Good fit", applicationEntity.getReviewMessage());
         verify(applicationEventPublisher).publishEvent(any(Object.class));
 
         // Verify the team size was persisted
         verify(projectRepository).save(any(ProjectEntity.class));
+    }
+
+    @Test
+    @DisplayName("Should reject application and persist review message")
+    void shouldRejectApplicationAndPersistReviewMessage_whenApplicationExists() {
+        ReviewApplicationCommand command =
+                new ReviewApplicationCommand(
+                        applicationId, ApplicationStatus.REJECTED, "Need a different skill set");
+
+        ProjectApplication domainApp = new ProjectApplication();
+        when(applicationMapper.entityToDomain(applicationEntity)).thenReturn(domainApp);
+
+        when(applicationRepository.findById(applicationId))
+                .thenReturn(Optional.of(applicationEntity));
+        when(applicationRepository.save(applicationEntity)).thenReturn(applicationEntity);
+
+        ApiResponse<ReviewApplicationCommandResult> response = handler.handle(command);
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(ApplicationStatus.REJECTED, applicationEntity.getStatus());
+        assertEquals("Need a different skill set", applicationEntity.getReviewMessage());
+        verify(applicationEventPublisher).publishEvent(any(Object.class));
+        verify(projectRepository, never()).save(any(ProjectEntity.class));
     }
 
     @Test

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectApplications/GetProjectApplicationsHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getProjectApplications/GetProjectApplicationsHandlerTest.java
@@ -132,6 +132,7 @@ class GetProjectApplicationsHandlerTest {
     void shouldMapEntityToDto_correctly() {
         UserEntity applicant = buildUser();
         ProjectApplicationEntity app = buildApp(applicant, ApplicationStatus.APPROVED);
+        app.setReviewMessage("Welcome aboard");
 
         when(projectRepository.findById(projectId)).thenReturn(Optional.of(projectEntity));
         when(applicationRepository.findByProjectIdWithOptionalStatus(projectId, null))
@@ -148,6 +149,7 @@ class GetProjectApplicationsHandlerTest {
         assertEquals(applicant.getId(), dto.applicantId());
         assertEquals("Bob Jones", dto.applicantName());
         assertEquals(ApplicationStatus.APPROVED, dto.status());
+        assertEquals("Welcome aboard", dto.reviewMessage());
     }
 
     private UserEntity buildUser() {

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserApplications/GetUserApplicationsHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserApplications/GetUserApplicationsHandlerTest.java
@@ -102,6 +102,7 @@ class GetUserApplicationsHandlerTest {
     @DisplayName("Should map application entity fields to ApplicationDto correctly")
     void shouldMapEntityToDto_correctly() {
         ProjectApplicationEntity app = buildApp(ApplicationStatus.PENDING);
+        app.setReviewMessage("Thanks for applying");
         Page<ProjectApplicationEntity> page = new PageImpl<>(List.of(app));
         when(applicationRepository.findWithFilters(
                         isNull(), isNull(), eq(user.getId()), any(Pageable.class)))
@@ -117,6 +118,7 @@ class GetUserApplicationsHandlerTest {
         assertEquals(user.getId(), dto.applicantId());
         assertEquals("Jane Doe", dto.applicantName());
         assertEquals(ApplicationStatus.PENDING, dto.status());
+        assertEquals("Thanks for applying", dto.reviewMessage());
     }
 
     private ProjectApplicationEntity buildApp(ApplicationStatus status) {

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ApplicationControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ApplicationControllerIntegrationTest.java
@@ -424,12 +424,13 @@ class ApplicationControllerIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
-        @DisplayName("8. Review with optional review message is included in response")
-        void reviewApplication_withMessage_returns200() throws Exception {
+        @DisplayName("8. Approval review message is persisted and queryable")
+        void reviewApplication_approvalMessage_isPersistedAndQueryable() throws Exception {
             String ownerToken = createProjectOwnerAndGetToken();
             String projectId = createProjectAndGetId(ownerToken);
             String applicantToken = createApplicantAndGetToken(APPLICANT_EMAIL, "Mehmet");
             String applicationId = createApplicationAndGetId(projectId, applicantToken);
+            String reviewMessage = "Great portfolio! Welcome aboard.";
 
             String reviewBody =
                     """
@@ -446,6 +447,58 @@ class ApplicationControllerIntegrationTest extends IntegrationTestBase {
                                     .content(reviewBody))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.status").value("APPROVED"));
+
+            var savedApp = applicationRepository.findById(applicationId).orElseThrow();
+            assertThat(savedApp.getReviewMessage()).isEqualTo(reviewMessage);
+
+            mockMvc.perform(
+                            get(MY_APPLICATIONS_URL)
+                                    .header("Authorization", "Bearer " + applicantToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.applications.length()").value(1))
+                    .andExpect(
+                            jsonPath("$.data.applications[0].applicationId").value(applicationId))
+                    .andExpect(jsonPath("$.data.applications[0].status").value("APPROVED"))
+                    .andExpect(
+                            jsonPath("$.data.applications[0].reviewMessage").value(reviewMessage));
+        }
+
+        @Test
+        @DisplayName("9. Rejection review message is persisted and queryable")
+        void reviewApplication_rejectionMessage_isPersistedAndQueryable() throws Exception {
+            String ownerToken = createProjectOwnerAndGetToken();
+            String projectId = createProjectAndGetId(ownerToken);
+            String applicantToken = createApplicantAndGetToken(APPLICANT_EMAIL, "Mehmet");
+            String applicationId = createApplicationAndGetId(projectId, applicantToken);
+            String reviewMessage = "Unfortunately we need different skills.";
+
+            String reviewBody =
+                    """
+                    {
+                        "status": "REJECTED",
+                        "reviewMessage": "Unfortunately we need different skills."
+                    }
+                    """;
+
+            mockMvc.perform(
+                            put(reviewApplicationUrl(applicationId))
+                                    .header("Authorization", "Bearer " + ownerToken)
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(reviewBody))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.status").value("REJECTED"));
+
+            var savedApp = applicationRepository.findById(applicationId).orElseThrow();
+            assertThat(savedApp.getReviewMessage()).isEqualTo(reviewMessage);
+
+            mockMvc.perform(
+                            get(projectApplicationsUrl(projectId))
+                                    .header("Authorization", "Bearer " + ownerToken))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.length()").value(1))
+                    .andExpect(jsonPath("$.data[0].applicationId").value(applicationId))
+                    .andExpect(jsonPath("$.data[0].status").value("REJECTED"))
+                    .andExpect(jsonPath("$.data[0].reviewMessage").value(reviewMessage));
         }
     }
 


### PR DESCRIPTION
Summary: persists reviewMessage on reviewed project applications, exposes it through ApplicationDto query responses, and adds the review_message migration plus approval/rejection coverage. Verification: ./gradlew test --tests ReviewApplicationHandlerTest --tests GetProjectApplicationsHandlerTest --tests GetUserApplicationsHandlerTest --tests ApplicationControllerIntegrationTest; ./gradlew --no-configuration-cache spotlessCheck. Closes #131