### PR TITLE
refactor(error): separate user-safe message from machine-readable errorCode (#137)

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminFeatureProject/AdminFeatureProjectHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/adminFeatureProject/AdminFeatureProjectHandler.java
@@ -2,6 +2,8 @@ package com.iyte_yazilim.proje_pazari.application.commands.adminFeatureProject;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +16,7 @@ public class AdminFeatureProjectHandler
         implements IRequestHandler<AdminFeatureProjectCommand, ApiResponse<Void>> {
 
     private final ProjectRepository projectRepository;
+    private final MessageService messageService;
 
     @Override
     @Transactional
@@ -21,16 +24,14 @@ public class AdminFeatureProjectHandler
         ProjectEntity project = projectRepository.findById(command.projectId()).orElse(null);
 
         if (project == null) {
-            return ApiResponse.notFound("Project not found with id: " + command.projectId());
+            throw new ProjectNotFoundException(command.projectId());
         }
 
         project.setFeatured(command.featured());
         projectRepository.save(project);
 
-        String message =
-                command.featured()
-                        ? "Project featured successfully"
-                        : "Project unfeatured successfully";
-        return ApiResponse.success(null, message);
+        String messageKey =
+                command.featured() ? "project.featured.success" : "project.unfeatured.success";
+        return ApiResponse.success(null, messageService.getMessage(messageKey));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/loginUser/LoginUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/loginUser/LoginUserHandler.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.commands.loginUser;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
@@ -56,19 +57,23 @@ public class LoginUserHandler
         UserEntity user = userRepository.findByEmail(command.email()).orElse(null);
         if (user == null) {
             metricsService.incrementAuthLoginFailure();
-            return ApiResponse.badRequest(messageService.getMessage("auth.login.failed"));
+            return ApiResponse.failure(
+                    ErrorCode.INVALID_CREDENTIALS, messageService.getMessage("auth.login.failed"));
         }
 
         // --- 3. Check if account is active ---
         if (user.getIsActive() == null || !user.getIsActive()) {
             metricsService.incrementAuthLoginFailure();
-            return ApiResponse.badRequest(messageService.getMessage("auth.account.deactivated"));
+            return ApiResponse.failure(
+                    ErrorCode.ACCOUNT_DEACTIVATED,
+                    messageService.getMessage("auth.account.deactivated"));
         }
 
         // --- 4. Verify password with BCrypt ---
         if (!passwordEncoder.matches(command.password(), user.getPassword())) {
             metricsService.incrementAuthLoginFailure();
-            return ApiResponse.badRequest(messageService.getMessage("auth.login.failed"));
+            return ApiResponse.failure(
+                    ErrorCode.INVALID_CREDENTIALS, messageService.getMessage("auth.login.failed"));
         }
 
         // --- 5. Check email verification ---

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/reviewApplication/ReviewApplicationHandler.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.commands.reviewApplication;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.entities.Project;
@@ -16,6 +17,7 @@ import com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers.ProjectM
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectApplicationEntity;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
@@ -35,6 +37,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class ReviewApplicationHandler
         implements IRequestHandler<
                 ReviewApplicationCommand, ApiResponse<ReviewApplicationCommandResult>> {
@@ -91,8 +94,10 @@ public class ReviewApplicationHandler
                 projectRepository.save(projectEntity); // Persist the new team size
 
             } catch (IllegalStateException e) {
-                // Catch the capacity limit exception thrown by the domain
-                return ApiResponse.badRequest(e.getMessage());
+                log.warn("Project capacity check failed: {}", e.getMessage());
+                return ApiResponse.failure(
+                        ErrorCode.ILLEGAL_APPLICATION_STATE,
+                        messageService.getMessage("application.illegal.state"));
             }
 
             // --- 3b. Approve via domain aggregate (enforces PENDING guard) ---

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/submitApplication/SubmitApplicationHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/submitApplication/SubmitApplicationHandler.java
@@ -1,9 +1,12 @@
 package com.iyte_yazilim.proje_pazari.application.commands.submitApplication;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.events.ApplicationSubmittedEvent;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.results.SubmitApplicationCommandResult;
 import com.iyte_yazilim.proje_pazari.infrastructure.metrics.BusinessMetricsService;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectApplicationRepository;
@@ -56,17 +59,14 @@ public class SubmitApplicationHandler
         ProjectEntity projectEntity = projectRepository.findById(command.projectId()).orElse(null);
         if (projectEntity == null) {
             metricsService.incrementApplicationSubmissionFailure();
-            return ApiResponse.notFound(
-                    messageService.getMessage(
-                            "project.not.found", new Object[] {command.projectId()}));
+            throw new ProjectNotFoundException(command.projectId());
         }
 
         // --- 3. Verify User Exists ---
         UserEntity userEntity = userRepository.findById(command.userId()).orElse(null);
         if (userEntity == null) {
             metricsService.incrementApplicationSubmissionFailure();
-            return ApiResponse.notFound(
-                    messageService.getMessage("user.not.found", new Object[] {command.userId()}));
+            throw new UserNotFoundException(command.userId());
         }
 
         // --- 4. Check for Duplicate Application ---
@@ -75,7 +75,9 @@ public class SubmitApplicationHandler
                         command.projectId(), command.userId());
         if (alreadyApplied) {
             metricsService.incrementApplicationSubmissionFailure();
-            return ApiResponse.badRequest(messageService.getMessage("application.already.exists"));
+            return ApiResponse.failure(
+                    ErrorCode.APPLICATION_ALREADY_EXISTS,
+                    messageService.getMessage("application.already.exists"));
         }
 
         // --- 5. Create Application Entity (defaults to PENDING status) ---

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateProjectStatus/UpdateProjectStatusHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateProjectStatus/UpdateProjectStatusHandler.java
@@ -1,12 +1,14 @@
 package com.iyte_yazilim.proje_pazari.application.commands.updateProjectStatus;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.entities.Project;
 import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
 import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 import com.iyte_yazilim.proje_pazari.domain.events.ProjectStatusChangedEvent;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.results.UpdateProjectStatusCommandResult;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectApplicationRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
@@ -15,6 +17,7 @@ import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEn
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
@@ -33,6 +36,7 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Component
 @RequiredArgsConstructor
+@Slf4j
 public class UpdateProjectStatusHandler
         implements IRequestHandler<
                 UpdateProjectStatusCommand, ApiResponse<UpdateProjectStatusCommandResult>> {
@@ -55,9 +59,7 @@ public class UpdateProjectStatusHandler
         // --- 1. Verify Project Exists ---
         ProjectEntity projectEntity = projectRepository.findById(command.projectId()).orElse(null);
         if (projectEntity == null) {
-            return ApiResponse.notFound(
-                    messageService.getMessage(
-                            "project.not.found", new Object[] {command.projectId()}));
+            throw new ProjectNotFoundException(command.projectId());
         }
 
         // --- 2. Store Old Status ---
@@ -65,7 +67,9 @@ public class UpdateProjectStatusHandler
 
         // --- 3. Check if status is actually changing ---
         if (oldStatus == command.newStatus()) {
-            return ApiResponse.badRequest(messageService.getMessage("project.status.unchanged"));
+            return ApiResponse.failure(
+                    ErrorCode.INVALID_ARGUMENT,
+                    messageService.getMessage("project.status.unchanged"));
         }
 
         // --- 4. Validate and Apply Transition via Domain Model ---
@@ -74,8 +78,14 @@ public class UpdateProjectStatusHandler
             // The domain dictates if this is legal!
             projectDomain.transitionTo(command.newStatus());
         } catch (IllegalStateException | IllegalArgumentException e) {
-            // Catch the domain exception and return it as a clean API response
-            return ApiResponse.badRequest(e.getMessage());
+            log.warn(
+                    "Invalid project status transition [{}->{}]: {}",
+                    oldStatus,
+                    command.newStatus(),
+                    e.getMessage());
+            return ApiResponse.failure(
+                    ErrorCode.INVALID_ARGUMENT,
+                    messageService.getMessage("project.status.transition.invalid"));
         }
 
         // --- 5. Update Entity Status ---

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandler.java
@@ -3,7 +3,7 @@ package com.iyte_yazilim.proje_pazari.application.commands.uploadFile;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,28 +21,23 @@ public class UploadFileHandler
     @Override
     public ApiResponse<Map<String, Object>> handle(UploadFileCommand command) {
         if (command.file() == null || command.file().isEmpty()) {
-            return ApiResponse.badRequest("File is empty");
+            throw new FileValidationException("Empty file rejected");
         }
 
         String filename = command.file().getOriginalFilename();
         if (filename == null || filename.isBlank() || filename.contains("..")) {
-            return ApiResponse.badRequest("Invalid filename");
+            throw new FileValidationException("Invalid filename: " + filename);
         }
 
-        try {
-            String filePath = fileStorageService.storeFile(command.file(), DEFAULT_DIRECTORY);
-            Map<String, Object> fileData =
-                    Map.of(
-                            "filename",
-                            filename,
-                            "url",
-                            "/api/v1/files/" + filePath,
-                            "size",
-                            command.file().getSize());
-            return ApiResponse.success(fileData, "File uploaded successfully");
-        } catch (FileStorageException e) {
-            log.error("File upload failed: {}", e.getMessage());
-            return ApiResponse.error("File upload failed: " + e.getMessage());
-        }
+        String filePath = fileStorageService.storeFile(command.file(), DEFAULT_DIRECTORY);
+        Map<String, Object> fileData =
+                Map.of(
+                        "filename",
+                        filename,
+                        "url",
+                        "/api/v1/files/" + filePath,
+                        "size",
+                        command.file().getSize());
+        return ApiResponse.success(fileData, "File uploaded successfully");
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ApiResponse.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ApiResponse.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.application.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
 /**
@@ -9,6 +10,17 @@ import java.time.LocalDateTime;
  * <p>Represents a standardized HTTP response body. Adheres to Clean Architecture by decoupling
  * internal logic from external JSON structure.
  *
+ * <p>On errors, two code fields are populated:
+ *
+ * <ul>
+ *   <li>{@code code} — a coarse {@link ResponseCode} HTTP-category bucket (kept for backward
+ *       compatibility);
+ *   <li>{@code errorCode} — a granular, stable {@link ErrorCode} string that clients can branch on.
+ * </ul>
+ *
+ * <p>The {@code message} is always a localized, user-safe string. Technical detail is never placed
+ * here — it stays in server logs.
+ *
  * @param <T> the type of data contained in the response
  */
 @JsonInclude(JsonInclude.Include.NON_NULL) // 1. Don't send "data": null to the client on errors
@@ -16,15 +28,38 @@ import java.time.LocalDateTime;
 public class ApiResponse<T> {
 
     private final T data;
+
+    @Schema(
+            description = "Localized, user-safe message. Safe to display directly to end users.",
+            example = "Kullanıcı bulunamadı")
     private final String message;
+
+    @Schema(
+            description = "Coarse HTTP-category response code. Kept for backward compatibility.",
+            example = "7")
     private final ResponseCode code; // 2. Using the Enum strictly
+
+    @Schema(
+            description =
+                    "Stable, granular machine-readable error identifier. Present only on error"
+                            + " responses; clients should branch on this rather than on `code` or"
+                            + " `message`.",
+            example = "USER_NOT_FOUND")
+    private final ErrorCode errorCode; // 2b. Null on success responses
+
     private final LocalDateTime timestamp; // 3. Audit trail
 
-    // Private constructor enforces usage of static factory methods
+    // Private constructors enforce usage of static factory methods
+
     private ApiResponse(T data, String message, ResponseCode code) {
+        this(data, message, code, null);
+    }
+
+    private ApiResponse(T data, String message, ResponseCode code, ErrorCode errorCode) {
         this.data = data;
         this.message = message;
         this.code = code;
+        this.errorCode = errorCode;
         this.timestamp = LocalDateTime.now();
     }
 
@@ -47,6 +82,17 @@ public class ApiResponse<T> {
     }
 
     // --- ERROR RESPONSES ---
+
+    /**
+     * Preferred factory for error responses. Derives the coarse {@code code} from the {@link
+     * ErrorCode} category and records the granular {@code errorCode} for client branching.
+     *
+     * @param errorCode the granular, stable error identifier
+     * @param message a localized, user-safe message (never technical detail)
+     */
+    public static <T> ApiResponse<T> failure(ErrorCode errorCode, String message) {
+        return new ApiResponse<>(null, message, errorCode.getCategory(), errorCode);
+    }
 
     public static <T> ApiResponse<T> badRequest(String message) {
         // Fix: Use Enum, do not pass raw '400' int
@@ -95,6 +141,10 @@ public class ApiResponse<T> {
 
     public ResponseCode getCode() {
         return this.code;
+    }
+
+    public ErrorCode getErrorCode() {
+        return this.errorCode;
     }
 
     public LocalDateTime getTimestamp() {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCode.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCode.java
@@ -1,0 +1,114 @@
+package com.iyte_yazilim.proje_pazari.application.common;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Stable, machine-readable error identifier returned in the {@code errorCode} field of {@link
+ * ApiResponse}.
+ *
+ * <p>Unlike {@link ResponseCode} — which is a coarse HTTP-category bucket — {@code ErrorCode} is
+ * granular: clients can branch reliably on a specific failure (e.g. distinguishing {@code
+ * USER_NOT_FOUND} from {@code PROJECT_NOT_FOUND}, both of which map to the same {@code NOT_FOUND}
+ * category).
+ *
+ * <p>Each constant carries:
+ *
+ * <ul>
+ *   <li>a {@link ResponseCode} <b>category</b> — drives the numeric {@code code} field and the HTTP
+ *       status of the response;
+ *   <li>a <b>message key</b> — resolved via {@code MessageService} into a localized, user-safe
+ *       message. Technical detail is never derived from this; it stays in server logs.
+ * </ul>
+ *
+ * <p>The enum {@code name()} is the wire value (serialized via {@link JsonValue}); treat these
+ * names as a public API contract and avoid renaming existing constants.
+ */
+@Getter
+@AllArgsConstructor
+@SuppressWarnings("unused")
+public enum ErrorCode {
+
+    // --- Request / validation errors ---
+    /** Request body or parameters failed validation. */
+    VALIDATION_ERROR(ResponseCode.VALIDATION_ERROR, "error.validation"),
+
+    /** Request body could not be parsed (malformed JSON, wrong content type, etc.). */
+    MALFORMED_REQUEST(ResponseCode.BAD_REQUEST, "error.bad.request"),
+
+    /** A required request parameter was missing. */
+    MISSING_PARAMETER(ResponseCode.BAD_REQUEST, "error.bad.request"),
+
+    /** A supplied argument was rejected by domain or application logic. */
+    INVALID_ARGUMENT(ResponseCode.BAD_REQUEST, "error.bad.request"),
+
+    // --- Authentication / authorization errors ---
+    /** Authentication is required or the supplied credentials are invalid. */
+    UNAUTHORIZED(ResponseCode.UNAUTHORIZED, "error.unauthorized"),
+
+    /** The authenticated principal lacks permission for the requested action. */
+    ACCESS_DENIED(ResponseCode.FORBIDDEN, "error.forbidden"),
+
+    // --- Not-found errors ---
+    /** No user matches the supplied identifier. */
+    USER_NOT_FOUND(ResponseCode.NOT_FOUND, "user.not.found"),
+
+    /** No project matches the supplied identifier. */
+    PROJECT_NOT_FOUND(ResponseCode.NOT_FOUND, "project.not.found"),
+
+    /** No project application matches the supplied identifier. */
+    APPLICATION_NOT_FOUND(ResponseCode.NOT_FOUND, "application.not.found"),
+
+    /** No flagged content matches the supplied identifier. */
+    FLAGGED_CONTENT_NOT_FOUND(ResponseCode.NOT_FOUND, "flag.not.found"),
+
+    // --- Email / verification errors ---
+    /** The account's email address has not been verified yet. */
+    EMAIL_NOT_VERIFIED(ResponseCode.FORBIDDEN, "auth.email.not.verified"),
+
+    /** The account's email address is already verified. */
+    EMAIL_ALREADY_VERIFIED(ResponseCode.CONFLICT, "auth.email.already.verified.error"),
+
+    /** The verification token has expired. */
+    VERIFICATION_TOKEN_EXPIRED(ResponseCode.BAD_REQUEST, "auth.verification.token.expired"),
+
+    /** The verification token is invalid or already used. */
+    INVALID_VERIFICATION_TOKEN(ResponseCode.BAD_REQUEST, "auth.verification.token.invalid"),
+
+    /** Sending an email failed. */
+    EMAIL_SEND_FAILED(ResponseCode.INTERNAL_SERVER_ERROR, "error.internal"),
+
+    // --- File errors ---
+    /** Uploaded file exceeds the maximum allowed size. */
+    FILE_TOO_LARGE(ResponseCode.VALIDATION_ERROR, "validation.file.size.exceeded"),
+
+    /** Uploaded file failed validation (wrong type, corrupt, etc.). */
+    FILE_VALIDATION_FAILED(ResponseCode.BAD_REQUEST, "validation.file.type.invalid"),
+
+    /** A file storage operation failed. */
+    FILE_STORAGE_ERROR(ResponseCode.INTERNAL_SERVER_ERROR, "error.internal"),
+
+    // --- Domain state errors ---
+    /** A user lifecycle method was invoked from an invalid current state. */
+    ILLEGAL_USER_STATE(ResponseCode.CONFLICT, "user.illegal.state"),
+
+    /** A project-application workflow method was invoked from an invalid current status. */
+    ILLEGAL_APPLICATION_STATE(ResponseCode.CONFLICT, "application.illegal.state"),
+
+    // --- Catch-all ---
+    /** An unexpected, unclassified server error occurred. */
+    INTERNAL_ERROR(ResponseCode.INTERNAL_SERVER_ERROR, "error.internal");
+
+    /** Coarse HTTP-category bucket; drives the numeric {@code code} field and the HTTP status. */
+    private final ResponseCode category;
+
+    /** Message-bundle key resolved into a localized, user-safe message. */
+    private final String messageKey;
+
+    /** The stable wire value of this error code (its {@code name()}). */
+    @JsonValue
+    public String getValue() {
+        return name();
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCode.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCode.java
@@ -50,6 +50,15 @@ public enum ErrorCode {
     /** The authenticated principal lacks permission for the requested action. */
     ACCESS_DENIED(ResponseCode.FORBIDDEN, "error.forbidden"),
 
+    /**
+     * The supplied credentials are invalid (wrong email or password). Kept vague to prevent user
+     * enumeration.
+     */
+    INVALID_CREDENTIALS(ResponseCode.BAD_REQUEST, "auth.login.failed"),
+
+    /** The account exists but has been administratively deactivated. */
+    ACCOUNT_DEACTIVATED(ResponseCode.FORBIDDEN, "auth.account.deactivated"),
+
     // --- Not-found errors ---
     /** No user matches the supplied identifier. */
     USER_NOT_FOUND(ResponseCode.NOT_FOUND, "user.not.found"),
@@ -62,6 +71,9 @@ public enum ErrorCode {
 
     /** No flagged content matches the supplied identifier. */
     FLAGGED_CONTENT_NOT_FOUND(ResponseCode.NOT_FOUND, "flag.not.found"),
+
+    /** A user has already submitted an application to the same project. */
+    APPLICATION_ALREADY_EXISTS(ResponseCode.CONFLICT, "application.already.exists"),
 
     // --- Email / verification errors ---
     /** The account's email address has not been verified yet. */

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ResponseCode.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ResponseCode.java
@@ -93,7 +93,7 @@ public enum ResponseCode {
         return switch (this) {
             case SUCCESS -> HttpStatus.OK;
             case NO_CONTENT -> HttpStatus.NO_CONTENT;
-            case CREATED -> HttpStatus.CREATED;
+            case CREATED, REGISTERED_NEEDS_VERIFICATION -> HttpStatus.CREATED;
             case ACCEPTED -> HttpStatus.ACCEPTED;
             case BAD_REQUEST, VALIDATION_ERROR -> HttpStatus.BAD_REQUEST;
             case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ResponseCode.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ResponseCode.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 /**
  * Enumeration of response codes used in API responses.
@@ -79,5 +80,27 @@ public enum ResponseCode {
             }
         }
         throw new IllegalArgumentException();
+    }
+
+    /**
+     * Maps this response code to the HTTP status it should be served with. Keeping the mapping here
+     * lets callers (e.g. {@code GlobalExceptionHandler}) derive the status in one place instead of
+     * hardcoding it per exception handler.
+     *
+     * @return the corresponding {@link HttpStatus}
+     */
+    public HttpStatus httpStatus() {
+        return switch (this) {
+            case SUCCESS -> HttpStatus.OK;
+            case NO_CONTENT -> HttpStatus.NO_CONTENT;
+            case CREATED -> HttpStatus.CREATED;
+            case ACCEPTED -> HttpStatus.ACCEPTED;
+            case BAD_REQUEST, VALIDATION_ERROR -> HttpStatus.BAD_REQUEST;
+            case UNAUTHORIZED -> HttpStatus.UNAUTHORIZED;
+            case FORBIDDEN -> HttpStatus.FORBIDDEN;
+            case NOT_FOUND -> HttpStatus.NOT_FOUND;
+            case CONFLICT -> HttpStatus.CONFLICT;
+            case INTERNAL_SERVER_ERROR -> HttpStatus.INTERNAL_SERVER_ERROR;
+        };
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/exceptions/ValidationException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/exceptions/ValidationException.java
@@ -1,13 +1,16 @@
 package com.iyte_yazilim.proje_pazari.application.exceptions;
 
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.DomainException;
+
 /** Exception thrown when request validation fails. */
-public class ValidationException extends RuntimeException {
+public class ValidationException extends DomainException {
 
     public ValidationException(String message) {
-        super(message);
+        super(ErrorCode.VALIDATION_ERROR, message);
     }
 
     public ValidationException(String message, Throwable cause) {
-        super(message, cause);
+        super(ErrorCode.VALIDATION_ERROR, message, cause);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/adminGetUser/AdminGetUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/adminGetUser/AdminGetUserHandler.java
@@ -3,6 +3,8 @@ package com.iyte_yazilim.proje_pazari.application.queries.adminGetUser;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserAdminDTO;
+import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
 import lombok.RequiredArgsConstructor;
@@ -14,13 +16,14 @@ public class AdminGetUserHandler
         implements IRequestHandler<AdminGetUserQuery, ApiResponse<UserAdminDTO>> {
 
     private final UserRepository userRepository;
+    private final MessageService messageService;
 
     @Override
     public ApiResponse<UserAdminDTO> handle(AdminGetUserQuery query) {
         UserEntity user = userRepository.findById(query.userId()).orElse(null);
 
         if (user == null) {
-            return ApiResponse.notFound("User not found with id: " + query.userId());
+            throw new UserNotFoundException(query.userId());
         }
 
         UserAdminDTO dto =
@@ -40,6 +43,6 @@ public class AdminGetUserHandler
                         userRepository.countProjectsByUserId(user.getId()),
                         userRepository.countApplicationsByUserId(user.getId()));
 
-        return ApiResponse.success(dto, "User details retrieved successfully");
+        return ApiResponse.success(dto, messageService.getMessage("user.retrieved.success"));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUser/GetUserHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUser/GetUserHandler.java
@@ -6,6 +6,7 @@ import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.application.mappers.UserDtoMapper;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.entities.User;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers.UserMapper;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -27,7 +28,8 @@ public class GetUserHandler implements IRequestHandler<GetUserQuery, ApiResponse
         // --- 1. Find user by ID ---
         UserEntity userEntity = userRepository.findById(query.userId()).orElse(null);
         if (userEntity == null) {
-            return ApiResponse.notFound(messageService.getMessage("user.not.found"));
+            // Enumeration-safe: the looked-up id is kept out of the response (logs only).
+            throw new UserNotFoundException();
         }
 
         // --- 2. Map to domain ---

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandler.java
@@ -6,6 +6,7 @@ import com.iyte_yazilim.proje_pazari.application.dtos.ProjectSummaryDTO;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserProfileDTO;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.RoleType;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
@@ -29,8 +30,8 @@ public class GetUserProfileHandler
         UserEntity user = userRepository.findById(query.userId()).orElse(null);
 
         if (user == null) {
-            return ApiResponse.notFound(
-                    messageService.getMessage("user.not.found", new Object[] {query.userId()}));
+            // Enumeration-safe: the looked-up id is kept out of the response (logs only).
+            throw new UserNotFoundException();
         }
 
         // Get user statistics

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ApplicationNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ApplicationNotFoundException.java
@@ -1,7 +1,9 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class ApplicationNotFoundException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class ApplicationNotFoundException extends DomainException {
     public ApplicationNotFoundException(String applicationId) {
-        super("Application not found: " + applicationId);
+        super(ErrorCode.APPLICATION_NOT_FOUND, "Application not found: " + applicationId);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/DomainException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/DomainException.java
@@ -1,0 +1,32 @@
+package com.iyte_yazilim.proje_pazari.domain.exceptions;
+
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+import lombok.Getter;
+
+/**
+ * Base type for all domain-level exceptions.
+ *
+ * <p>Every {@code DomainException} carries a stable {@link ErrorCode} that {@code
+ * GlobalExceptionHandler} translates into the {@code errorCode} field, the numeric {@code code} and
+ * the HTTP status of the response — without ever inspecting the exception subtype.
+ *
+ * <p>The {@code message} passed here is the <b>technical</b> message: it may contain identifiers,
+ * email addresses or other internal detail and is intended for server logs only. The user-facing
+ * message is resolved separately from {@link ErrorCode#getMessageKey()} and is always localized and
+ * safe to display.
+ */
+@Getter
+public class DomainException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public DomainException(ErrorCode errorCode, String technicalMessage) {
+        super(technicalMessage);
+        this.errorCode = errorCode;
+    }
+
+    public DomainException(ErrorCode errorCode, String technicalMessage, Throwable cause) {
+        super(technicalMessage, cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/EmailAlreadyVerifiedException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/EmailAlreadyVerifiedException.java
@@ -1,7 +1,9 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class EmailAlreadyVerifiedException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class EmailAlreadyVerifiedException extends DomainException {
     public EmailAlreadyVerifiedException(String message) {
-        super(message);
+        super(ErrorCode.EMAIL_ALREADY_VERIFIED, message);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/EmailNotVerifiedException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/EmailNotVerifiedException.java
@@ -1,7 +1,9 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class EmailNotVerifiedException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class EmailNotVerifiedException extends DomainException {
     public EmailNotVerifiedException(String message) {
-        super(message);
+        super(ErrorCode.EMAIL_NOT_VERIFIED, message);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/EmailSendException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/EmailSendException.java
@@ -1,7 +1,9 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class EmailSendException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class EmailSendException extends DomainException {
     public EmailSendException(String message, Throwable cause) {
-        super(message, cause);
+        super(ErrorCode.EMAIL_SEND_FAILED, message, cause);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FileStorageException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FileStorageException.java
@@ -1,12 +1,14 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class FileStorageException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class FileStorageException extends DomainException {
 
     public FileStorageException(String message) {
-        super(message);
+        super(ErrorCode.FILE_STORAGE_ERROR, message);
     }
 
     public FileStorageException(String message, Throwable cause) {
-        super(message, cause);
+        super(ErrorCode.FILE_STORAGE_ERROR, message, cause);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FileValidationException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FileValidationException.java
@@ -1,12 +1,14 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class FileValidationException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class FileValidationException extends DomainException {
 
     public FileValidationException(String message) {
-        super(message);
+        super(ErrorCode.FILE_VALIDATION_FAILED, message);
     }
 
     public FileValidationException(String message, Throwable cause) {
-        super(message, cause);
+        super(ErrorCode.FILE_VALIDATION_FAILED, message, cause);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FlaggedContentNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/FlaggedContentNotFoundException.java
@@ -1,7 +1,9 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class FlaggedContentNotFoundException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class FlaggedContentNotFoundException extends DomainException {
     public FlaggedContentNotFoundException(String flagId) {
-        super("Flagged content not found: " + flagId);
+        super(ErrorCode.FLAGGED_CONTENT_NOT_FOUND, "Flagged content not found: " + flagId);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/IllegalApplicationStateException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/IllegalApplicationStateException.java
@@ -1,5 +1,6 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
 
 /**
@@ -12,10 +13,11 @@ import com.iyte_yazilim.proje_pazari.domain.enums.ApplicationStatus;
  * @author IYTE Yazılım Topluluğu
  * @since 2026-04-04
  */
-public class IllegalApplicationStateException extends IllegalStateException {
+public class IllegalApplicationStateException extends DomainException {
 
     public IllegalApplicationStateException(String action, ApplicationStatus currentStatus) {
         super(
+                ErrorCode.ILLEGAL_APPLICATION_STATE,
                 String.format(
                         "Cannot %s application: current status is %s (expected PENDING)",
                         action, currentStatus));

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/IllegalUserStateException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/IllegalUserStateException.java
@@ -1,5 +1,7 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
 /**
  * Thrown when a {@link com.iyte_yazilim.proje_pazari.domain.entities.User} lifecycle method is
  * invoked from an invalid current state.
@@ -9,9 +11,9 @@ package com.iyte_yazilim.proje_pazari.domain.exceptions;
  * @author IYTE Yazılım Topluluğu
  * @since 2026-04-04
  */
-public class IllegalUserStateException extends IllegalStateException {
+public class IllegalUserStateException extends DomainException {
 
     public IllegalUserStateException(String message) {
-        super(message);
+        super(ErrorCode.ILLEGAL_USER_STATE, message);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/InvalidVerificationTokenException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/InvalidVerificationTokenException.java
@@ -1,7 +1,9 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class InvalidVerificationTokenException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class InvalidVerificationTokenException extends DomainException {
     public InvalidVerificationTokenException(String message) {
-        super(message);
+        super(ErrorCode.INVALID_VERIFICATION_TOKEN, message);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ProjectNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/ProjectNotFoundException.java
@@ -1,15 +1,16 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
 /**
  * Exception thrown when a project with the specified identifier cannot be found in the system.
  *
  * <p>This unchecked exception is typically used in service or repository layers when a lookup by
- * project ID fails. Callers are expected to catch this exception where appropriate and translate it
- * into a user-facing response, such as an HTTP 404 (Not Found) status or a "project not found"
- * message.
+ * project ID fails. {@code GlobalExceptionHandler} translates it into an HTTP 404 response with the
+ * {@code PROJECT_NOT_FOUND} error code; the technical message below is for server logs only.
  */
-public class ProjectNotFoundException extends RuntimeException {
+public class ProjectNotFoundException extends DomainException {
     public ProjectNotFoundException(String projectId) {
-        super("Project with ID " + projectId + " not found.");
+        super(ErrorCode.PROJECT_NOT_FOUND, "Project with ID " + projectId + " not found.");
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/UserNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/UserNotFoundException.java
@@ -1,16 +1,18 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class UserNotFoundException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class UserNotFoundException extends DomainException {
 
     public UserNotFoundException(String userId) {
-        super("User not found: " + userId);
+        super(ErrorCode.USER_NOT_FOUND, "User not found: " + userId);
     }
 
     /**
-     * Use this constructor when the lookup key must not be reflected in the API response to prevent
-     * user enumeration attacks (e.g., email-based lookups from public endpoints).
+     * Use this constructor when the lookup key must not be reflected in logs or responses to
+     * prevent user enumeration attacks (e.g., email-based lookups from public endpoints).
      */
     public UserNotFoundException() {
-        super("User not found");
+        super(ErrorCode.USER_NOT_FOUND, "User not found");
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/VerificationTokenExpiredException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/VerificationTokenExpiredException.java
@@ -1,7 +1,9 @@
 package com.iyte_yazilim.proje_pazari.domain.exceptions;
 
-public class VerificationTokenExpiredException extends RuntimeException {
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+public class VerificationTokenExpiredException extends DomainException {
     public VerificationTokenExpiredException(String message) {
-        super(message);
+        super(ErrorCode.VERIFICATION_TOKEN_EXPIRED, message);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -1,30 +1,16 @@
 package com.iyte_yazilim.proje_pazari.presentation.config;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
-import com.iyte_yazilim.proje_pazari.application.exceptions.ValidationException;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.ApplicationNotFoundException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.EmailAlreadyVerifiedException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.EmailNotVerifiedException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.EmailSendException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FlaggedContentNotFoundException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.InvalidVerificationTokenException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.VerificationTokenExpiredException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.DomainException;
 import jakarta.validation.ConstraintViolationException;
-import java.util.HashMap;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -34,6 +20,20 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 
+/**
+ * Translates exceptions into standardized {@link ApiResponse} error bodies.
+ *
+ * <p>Two invariants every handler upholds:
+ *
+ * <ul>
+ *   <li>the response {@code message} is always resolved from the message bundle — localized and
+ *       safe to show users; raw {@code ex.getMessage()} is never sent to the client;
+ *   <li>technical detail (identifiers, emails, stack traces) goes to the server log only.
+ * </ul>
+ *
+ * <p>Domain-level failures are all handled by a single {@link #handleDomainException} method — the
+ * specific {@link ErrorCode} is carried by the {@link DomainException} itself.
+ */
 @RestControllerAdvice
 @RequiredArgsConstructor
 @Slf4j
@@ -41,75 +41,75 @@ public class GlobalExceptionHandler {
 
     private final MessageService messageService;
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ApiResponse<Map<String, String>>> handleValidationExceptions(
-            MethodArgumentNotValidException ex) {
-        Map<String, String> errors = new HashMap<>();
-        ex.getBindingResult()
-                .getAllErrors()
-                .forEach(
-                        (error) -> {
-                            String fieldName = ((FieldError) error).getField();
-                            String errorMessage = error.getDefaultMessage();
-                            errors.put(fieldName, errorMessage);
-                        });
+    /**
+     * Builds a localized, user-safe error response for the given {@link ErrorCode}. The user
+     * message is resolved from the message bundle; the HTTP status comes from the error code's
+     * category.
+     */
+    private ResponseEntity<ApiResponse<Void>> respond(ErrorCode errorCode) {
+        ApiResponse<Void> body =
+                ApiResponse.failure(
+                        errorCode, messageService.getMessage(errorCode.getMessageKey()));
+        return ResponseEntity.status(errorCode.getCategory().httpStatus()).body(body);
+    }
 
-        ApiResponse<Map<String, String>> response =
-                ApiResponse.validationError(messageService.getMessage("error.validation"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    // --- Domain exceptions: one handler; the ErrorCode is carried by the exception ---
+
+    @ExceptionHandler(DomainException.class)
+    public ResponseEntity<ApiResponse<Void>> handleDomainException(DomainException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        // Technical message may contain ids/emails/internal detail — log only, never expose.
+        log.warn("Domain exception [{}]: {}", errorCode, ex.getMessage());
+        return respond(errorCode);
+    }
+
+    // --- Framework / Spring exceptions ---
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationExceptions(
+            MethodArgumentNotValidException ex) {
+        log.warn("Request body validation failed: {}", ex.getMessage());
+        return respond(ErrorCode.VALIDATION_ERROR);
     }
 
     @ExceptionHandler(AuthenticationException.class)
     public ResponseEntity<ApiResponse<Void>> handleAuthenticationException(
             AuthenticationException ex) {
-        log.error("Authentication error: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.unauthorized(messageService.getMessage("error.unauthorized"));
-        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(response);
+        log.warn("Authentication error: {}", ex.getMessage());
+        return respond(ErrorCode.UNAUTHORIZED);
     }
 
     @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<ApiResponse<Void>> handleAccessDeniedException(AccessDeniedException ex) {
-        log.error("Access denied: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.forbidden(messageService.getMessage("error.forbidden"));
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+        log.warn("Access denied: {}", ex.getMessage());
+        return respond(ErrorCode.ACCESS_DENIED);
     }
 
     @ExceptionHandler(MaxUploadSizeExceededException.class)
     public ResponseEntity<ApiResponse<Void>> handleMaxUploadSizeExceededException(
             MaxUploadSizeExceededException ex) {
-        log.error("File upload size exceeded: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.validationError(
-                        messageService.getMessage("validation.file.size.exceeded"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        log.warn("File upload size exceeded: {}", ex.getMessage());
+        return respond(ErrorCode.FILE_TOO_LARGE);
     }
 
     @ExceptionHandler(MultipartException.class)
     public ResponseEntity<ApiResponse<Void>> handleMultipartException(MultipartException ex) {
-        log.error("Multipart request error: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.badRequest(messageService.getMessage("error.multipart.invalid"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        log.warn("Multipart request error: {}", ex.getMessage());
+        return respond(ErrorCode.MALFORMED_REQUEST);
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiResponse<Void>> handleHttpMessageNotReadableException(
             HttpMessageNotReadableException ex) {
-        log.warn("Message not readable: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.validationError(messageService.getMessage("error.validation"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        log.warn("Request body not readable: {}", ex.getMessage());
+        return respond(ErrorCode.MALFORMED_REQUEST);
     }
 
     @ExceptionHandler(MissingServletRequestParameterException.class)
     public ResponseEntity<ApiResponse<Void>> handleMissingServletRequestParameterException(
             MissingServletRequestParameterException ex) {
-        log.error("Missing request parameter: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.validationError(messageService.getMessage("error.validation"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        log.warn("Missing request parameter: {}", ex.getMessage());
+        return respond(ErrorCode.MISSING_PARAMETER);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
@@ -124,128 +124,34 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ConstraintViolationException.class)
     public ResponseEntity<ApiResponse<Void>> handleConstraintViolationException(
             ConstraintViolationException ex) {
-        log.error("Constraint violation: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.validationError(messageService.getMessage("error.validation"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        log.warn("Constraint violation: {}", ex.getMessage());
+        return respond(ErrorCode.VALIDATION_ERROR);
     }
 
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ResponseEntity<ApiResponse<Void>> handleHandlerMethodValidationException(
             HandlerMethodValidationException ex) {
-        log.error("Method validation error: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.validationError(messageService.getMessage("error.validation"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
-    @ExceptionHandler(ValidationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleValidationException(ValidationException ex) {
-        log.error("Validation error: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.validationError(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
-    @ExceptionHandler(FileValidationException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFileValidationException(
-            FileValidationException ex) {
-        log.warn("File validation error: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
-    @ExceptionHandler(FileStorageException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFileStorageException(FileStorageException ex) {
-        log.error("File storage error: {}", ex.getMessage(), ex.getCause());
-        ApiResponse<Void> response =
-                ApiResponse.internalError(messageService.getMessage("error.internal"));
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        log.warn("Handler method validation error: {}", ex.getMessage());
+        return respond(ErrorCode.VALIDATION_ERROR);
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ApiResponse<Void>> handleIllegalArgumentException(
             IllegalArgumentException ex) {
-        log.error("Illegal argument: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        // Raw entity/internal text may be in the message — log only, return a generic message.
+        log.warn("Illegal argument: {}", ex.getMessage());
+        return respond(ErrorCode.INVALID_ARGUMENT);
     }
 
-    @ExceptionHandler(UserNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleUserNotFoundException(UserNotFoundException ex) {
-        log.warn("User not found: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-    }
-
-    @ExceptionHandler(ProjectNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleProjectNotFoundException(
-            ProjectNotFoundException ex) {
-        log.warn("Project not found: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-    }
-
-    @ExceptionHandler(ApplicationNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleApplicationNotFoundException(
-            ApplicationNotFoundException ex) {
-        log.warn("Application not found: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-    }
-
-    @ExceptionHandler(FlaggedContentNotFoundException.class)
-    public ResponseEntity<ApiResponse<Void>> handleFlaggedContentNotFoundException(
-            FlaggedContentNotFoundException ex) {
-        log.warn("Flagged content not found: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.notFound(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
-    }
-
-    @ExceptionHandler(EmailNotVerifiedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleEmailNotVerifiedException(
-            EmailNotVerifiedException ex) {
-        log.warn("Email not verified: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.forbidden(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
-    }
-
-    @ExceptionHandler(EmailAlreadyVerifiedException.class)
-    public ResponseEntity<ApiResponse<Void>> handleEmailAlreadyVerifiedException(
-            EmailAlreadyVerifiedException ex) {
-        log.warn("Email already verified: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.conflict(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
-    }
-
-    @ExceptionHandler(VerificationTokenExpiredException.class)
-    public ResponseEntity<ApiResponse<Void>> handleVerificationTokenExpiredException(
-            VerificationTokenExpiredException ex) {
-        log.warn("Verification token expired: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
-    @ExceptionHandler(InvalidVerificationTokenException.class)
-    public ResponseEntity<ApiResponse<Void>> handleInvalidVerificationTokenException(
-            InvalidVerificationTokenException ex) {
-        log.warn("Invalid verification token: {}", ex.getMessage());
-        ApiResponse<Void> response = ApiResponse.badRequest(ex.getMessage());
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
-    }
-
-    @ExceptionHandler(EmailSendException.class)
-    public ResponseEntity<ApiResponse<Void>> handleEmailSendException(EmailSendException ex) {
-        log.error("Email send failed: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.internalError(messageService.getMessage("error.internal"));
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+    @ExceptionHandler(IllegalStateException.class)
+    public ResponseEntity<ApiResponse<Void>> handleIllegalStateException(IllegalStateException ex) {
+        log.error("Illegal state: {}", ex.getMessage());
+        return respond(ErrorCode.INTERNAL_ERROR);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ApiResponse<Void>> handleGlobalException(Exception ex) {
         log.error("Unexpected error occurred", ex);
-        ApiResponse<Void> response =
-                ApiResponse.internalError(messageService.getMessage("error.internal"));
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(response);
+        return respond(ErrorCode.INTERNAL_ERROR);
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -115,10 +115,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
     public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
             MethodArgumentTypeMismatchException ex) {
-        log.error("Request parameter type mismatch: {}", ex.getMessage());
-        ApiResponse<Void> response =
-                ApiResponse.badRequest(messageService.getMessage("error.validation"));
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+        log.warn("Request parameter type mismatch: {}", ex.getMessage());
+        return respond(ErrorCode.INVALID_ARGUMENT);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/AuthController.java
@@ -138,9 +138,9 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "BAD_REQUEST",
-                                            "message": "Email already exists",
-                                            "data": null
+                                            "code": 9,
+                                            "errorCode": "VALIDATION_ERROR",
+                                            "message": "This email address is already registered"
                                         }
                                         """)))
             })
@@ -190,7 +190,7 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "SUCCESS",
+                                            "code": 0,
                                             "message": "Login successful",
                                             "data": {
                                                 "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...",
@@ -200,7 +200,7 @@ public class AuthController extends BaseController {
                                                 }
                                         """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "400",
+                        responseCode = "401",
                         description = "Invalid credentials",
                         content =
                                 @Content(
@@ -212,9 +212,9 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "BAD_REQUEST",
-                                            "message": "Invalid email or password",
-                                            "data": null
+                                            "code": 5,
+                                            "errorCode": "UNAUTHORIZED",
+                                            "message": "Invalid username or password"
                                         }
                                         """)))
             })
@@ -343,7 +343,7 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "SUCCESS",
+                                            "code": 0,
                                             "message": "A password reset link has been sent to your email address",
                                             "data": null
                                         }
@@ -361,9 +361,9 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "BAD_REQUEST",
-                                            "message": "Invalid email format",
-                                            "data": null
+                                            "code": 9,
+                                            "errorCode": "VALIDATION_ERROR",
+                                            "message": "Invalid email address"
                                         }
                                         """)))
             })
@@ -391,7 +391,7 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "SUCCESS",
+                                            "code": 0,
                                             "message": "Your password has been reset successfully",
                                             "data": null
                                         }
@@ -409,9 +409,9 @@ public class AuthController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "BAD_REQUEST",
-                                            "message": "Invalid or already used password reset link",
-                                            "data": null
+                                            "code": 4,
+                                            "errorCode": "INVALID_VERIFICATION_TOKEN",
+                                            "message": "Invalid or already used password reset link"
                                         }
                                         """)))
             })

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -99,7 +99,7 @@ public class FileController extends BaseController {
                                                         value =
                                                                 """
                                         {
-                                            "code": "SUCCESS",
+                                            "code": 0,
                                             "message": "File uploaded successfully",
                                             "data": {
                                                 "filename": "document.pdf",

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
@@ -60,7 +60,7 @@ public class ProjectController extends BaseController {
                                                         value =
                                                                 """
                     {
-                        "code": "CREATED",
+                        "code": 2,
                         "message": "Project created successfully",
                         "data": {
                             "projectId": "01HQXV5KXBW9FYMN8CJZSP2R4H",
@@ -82,9 +82,9 @@ public class ProjectController extends BaseController {
                                                         value =
                                                                 """
                     {
-                        "code": "BAD_REQUEST",
-                        "message": "Title is required",
-                        "data": null
+                        "code": 9,
+                        "errorCode": "VALIDATION_ERROR",
+                        "message": "Validation error"
                     }
                     """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -99,9 +99,9 @@ public class ProjectController extends BaseController {
                                                         value =
                                                                 """
                     {
-                        "code": "UNAUTHORIZED",
-                        "message": "Authentication required",
-                        "data": null
+                        "code": 5,
+                        "errorCode": "UNAUTHORIZED",
+                        "message": "Unauthorized access"
                     }
                     """))),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -155,7 +155,7 @@ public class ProjectController extends BaseController {
                                                         value =
                                                                 """
                     {
-                        "code": "SUCCESS",
+                        "code": 0,
                         "message": "Projects retrieved successfully",
                         "data": [
                             {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -50,14 +50,23 @@ admin.cannot.be.demoted=ADMIN kullanıcıları düşürülemez
 # Project Messages
 project.created.success=Proje başarıyla oluşturuldu
 project.updated=Proje başarıyla güncellendi
+project.updated.success=Proje başarıyla güncellendi
 project.deleted=Proje başarıyla silindi
+project.deleted.success=Proje başarıyla silindi
 project.not.found=Proje bulunamadı
 project.status.updated.success=Proje durumu başarıyla güncellendi
 project.status.unchanged=Proje zaten bu durumda
+project.status.transition.invalid=Proje durumu bu geçişe izin vermiyor
 project.retrieved.success=Proje başarıyla getirildi
 project.list.retrieved.success=Proje listesi başarıyla getirildi
+projects.listed.success=Projeler başarıyla listelendi
 project.name.required=Proje adı gereklidir
 project.owner.not.found=Proje sahibi bulunamadı: {0}
+project.owner.mismatch=Bu işlem için proje sahibi olmanız gerekmektedir
+project.featured.success=Proje öne çıkarıldı
+project.unfeatured.success=Proje öne çıkarma kaldırıldı
+project.delete.has.active.work=Devam eden bir proje silinemez. Lütfen önce projeyi iptal edin
+project.update.not.allowed=Tamamlanmış veya iptal edilmiş bir proje güncellenemez
 
 # Application Messages
 application.submitted=Başvuru başarıyla gönderildi
@@ -65,8 +74,11 @@ application.submitted.success=Başvuru başarıyla gönderildi
 application.approved=Başvuru onaylandı
 application.rejected=Başvuru reddedildi
 application.not.found=Başvuru bulunamadı
-application.already.exists=Bu projeye zaten başvuru yapılmış
+application.already.exists=Bu projeye zaten başvurdunuz
 application.reviewed.success=Başvuru başarıyla değerlendirildi
+application.withdrawn.success=Başvuru başarıyla geri çekildi
+application.withdraw.forbidden=Yalnızca kendi başvurunuzu geri çekebilirsiniz
+application.withdraw.not.pending=Yalnızca beklemedeki başvurular geri çekilebilir
 application.list.retrieved.success=Başvuru listesi başarıyla getirildi
 
 # Error Messages
@@ -106,21 +118,3 @@ general.success=İşlem başarılı
 general.error=Bir hata oluştu
 general.not.found=Bulunamadı
 general.invalid=Geçersiz
-
-# Missing keys added for project/application handlers
-project.created.success=Proje başarıyla oluşturuldu
-project.updated.success=Proje başarıyla güncellendi
-project.deleted.success=Proje başarıyla silindi
-projects.listed.success=Projeler başarıyla listelendi
-project.owner.mismatch=Bu işlem için proje sahibi olmanız gerekmektedir
-project.status.unchanged=Proje zaten bu statüde
-project.status.updated.success=Proje statüsü başarıyla güncellendi
-application.submitted.success=Başvuru başarıyla gönderildi
-application.reviewed.success=Başvuru başarıyla değerlendirildi
-application.withdrawn.success=Başvuru başarıyla geri çekildi
-application.already.exists=Bu projeye zaten başvurdunuz
-application.withdraw.forbidden=Yalnızca kendi başvurunuzu geri çekebilirsiniz
-application.withdraw.not.pending=Yalnızca beklemedeki başvurular geri çekilebilir
-application.list.retrieved.success=Başvuru listesi başarıyla getirildi
-project.delete.has.active.work=Devam eden bir proje silinemez. Lütfen önce projeyi iptal edin
-project.update.not.allowed=Tamamlanmış veya iptal edilmiş bir proje güncellenemez

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -81,6 +81,15 @@ error.validation=Doğrulama hatası
 error.file.upload=Dosya yükleme hatası: {0}
 error.multipart.invalid=Geçersiz dosya yükleme isteği. Lütfen multipart/form-data kullanın
 
+# Error codes (ErrorCode enum -> user-safe message)
+flag.not.found=İçerik bildirimi bulunamadı
+auth.email.not.verified=E-posta adresiniz doğrulanmamış
+auth.email.already.verified.error=E-posta adresiniz zaten doğrulanmış
+auth.verification.token.expired=Doğrulama bağlantısının süresi dolmuş
+auth.verification.token.invalid=Geçersiz veya kullanılmış doğrulama bağlantısı
+user.illegal.state=Kullanıcı hesabı bu işlem için uygun durumda değil
+application.illegal.state=Başvuru bu işlem için uygun durumda değil
+
 # Field Names (for validation messages)
 field.email=E-posta
 field.password=Şifre

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -81,6 +81,15 @@ error.validation=Validation error
 error.file.upload=Failed to upload file: {0}
 error.multipart.invalid=Invalid file upload request. Please use multipart/form-data
 
+# Error codes (ErrorCode enum -> user-safe message)
+flag.not.found=Flagged content not found
+auth.email.not.verified=Your email address has not been verified
+auth.email.already.verified.error=Your email address is already verified
+auth.verification.token.expired=The verification link has expired
+auth.verification.token.invalid=Invalid or already used verification link
+user.illegal.state=The user account is not in a valid state for this action
+application.illegal.state=The application is not in a valid state for this action
+
 # Field Names (for validation messages)
 field.email=Email
 field.password=Password

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -50,14 +50,23 @@ admin.cannot.be.demoted=ADMIN users cannot be demoted
 # Project Messages
 project.created.success=Project created successfully
 project.updated=Project updated successfully
+project.updated.success=Project updated successfully
 project.deleted=Project deleted successfully
+project.deleted.success=Project deleted successfully
 project.not.found=Project not found
 project.status.updated.success=Project status updated successfully
 project.status.unchanged=Project is already in this status
+project.status.transition.invalid=Project status does not allow this transition
 project.retrieved.success=Project retrieved successfully
 project.list.retrieved.success=Projects retrieved successfully
+projects.listed.success=Projects retrieved successfully
 project.name.required=Project name is required
 project.owner.not.found=Owner with ID {0} not found
+project.owner.mismatch=You must be the project owner to perform this action
+project.featured.success=Project featured successfully
+project.unfeatured.success=Project unfeatured successfully
+project.delete.has.active.work=Cannot delete a project that is currently in progress. Please cancel the project first
+project.update.not.allowed=Cannot update a project that is completed or cancelled
 
 # Application Messages
 application.submitted=Application submitted successfully
@@ -67,6 +76,9 @@ application.rejected=Application rejected
 application.not.found=Application not found
 application.already.exists=You have already applied to this project
 application.reviewed.success=Application reviewed successfully
+application.withdrawn.success=Application withdrawn successfully
+application.withdraw.forbidden=You can only withdraw your own application
+application.withdraw.not.pending=Only pending applications can be withdrawn
 application.list.retrieved.success=Applications retrieved successfully
 
 # Error Messages
@@ -106,20 +118,3 @@ general.success=Operation successful
 general.error=An error occurred
 general.not.found=Not found
 general.invalid=Invalid
-# Missing keys added for project/application handlers
-project.created.success=Project created successfully
-project.updated.success=Project updated successfully
-project.deleted.success=Project deleted successfully
-projects.listed.success=Projects retrieved successfully
-project.owner.mismatch=You must be the project owner to perform this action
-project.status.unchanged=Project is already in this status
-project.status.updated.success=Project status updated successfully
-application.submitted.success=Application submitted successfully
-application.reviewed.success=Application reviewed successfully
-application.withdrawn.success=Application withdrawn successfully
-application.already.exists=You have already applied to this project
-application.withdraw.forbidden=You can only withdraw your own application
-application.withdraw.not.pending=Only pending applications can be withdrawn
-application.list.retrieved.success=Applications retrieved successfully
-project.delete.has.active.work=Cannot delete a project that is currently in progress. Please cancel the project first
-project.update.not.allowed=Cannot update a project that is completed or cancelled

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/loginUser/LoginUserHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/loginUser/LoginUserHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.*;
 
 import com.github.f4b6a3.ulid.Ulid;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.common.ResponseCode;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.models.results.LoginUserResult;
@@ -106,12 +107,13 @@ class LoginUserHandlerTest {
 
         // Then
         assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
+        assertEquals(ErrorCode.INVALID_CREDENTIALS, response.getErrorCode());
         assertEquals("Invalid email or password", response.getMessage());
         verify(passwordEncoder, never()).matches(anyString(), anyString());
     }
 
     @Test
-    @DisplayName("Should return error when account is deactivated")
+    @DisplayName("Should return forbidden when account is deactivated")
     void shouldReturnError_whenAccountIsDeactivated() {
         // Given
         String email = "deactivated@std.iyte.edu.tr";
@@ -130,13 +132,14 @@ class LoginUserHandlerTest {
         ApiResponse<LoginUserResult> response = handler.handle(command);
 
         // Then
-        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
+        assertEquals(ResponseCode.FORBIDDEN, response.getCode());
+        assertEquals(ErrorCode.ACCOUNT_DEACTIVATED, response.getErrorCode());
         assertEquals("Account has been deactivated", response.getMessage());
         verify(passwordEncoder, never()).matches(anyString(), anyString());
     }
 
     @Test
-    @DisplayName("Should return error when isActive is null")
+    @DisplayName("Should return forbidden when isActive is null")
     void shouldReturnError_whenIsActiveIsNull() {
         // Given
         String email = "nullactive@std.iyte.edu.tr";
@@ -155,7 +158,8 @@ class LoginUserHandlerTest {
         ApiResponse<LoginUserResult> response = handler.handle(command);
 
         // Then
-        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
+        assertEquals(ResponseCode.FORBIDDEN, response.getCode());
+        assertEquals(ErrorCode.ACCOUNT_DEACTIVATED, response.getErrorCode());
         assertEquals("Account has been deactivated", response.getMessage());
         verify(passwordEncoder, never()).matches(anyString(), anyString());
     }
@@ -186,6 +190,7 @@ class LoginUserHandlerTest {
 
         // Then
         assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
+        assertEquals(ErrorCode.INVALID_CREDENTIALS, response.getErrorCode());
         assertEquals("Invalid email or password", response.getMessage());
         verify(jwtUtil, never()).generateToken(anyString(), anyString(), anyString());
     }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/uploadFile/UploadFileHandlerTest.java
@@ -7,6 +7,7 @@ import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.ResponseCode;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -26,69 +27,49 @@ class UploadFileHandlerTest {
     @InjectMocks private UploadFileHandler handler;
 
     @Test
-    @DisplayName("Should return bad request when file is null")
-    void handle_nullFile_returnsBadRequest() {
+    @DisplayName("Should throw FileValidationException when file is null")
+    void handle_nullFile_throwsFileValidationException() {
         UploadFileCommand command = new UploadFileCommand(null);
-
-        ApiResponse<Map<String, Object>> response = handler.handle(command);
-
-        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
-        assertEquals("File is empty", response.getMessage());
+        assertThrows(FileValidationException.class, () -> handler.handle(command));
         verifyNoInteractions(fileStorageService);
     }
 
     @Test
-    @DisplayName("Should return bad request when file is empty")
-    void handle_emptyFile_returnsBadRequest() {
+    @DisplayName("Should throw FileValidationException when file is empty")
+    void handle_emptyFile_throwsFileValidationException() {
         when(mockFile.isEmpty()).thenReturn(true);
         UploadFileCommand command = new UploadFileCommand(mockFile);
-
-        ApiResponse<Map<String, Object>> response = handler.handle(command);
-
-        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
-        assertEquals("File is empty", response.getMessage());
+        assertThrows(FileValidationException.class, () -> handler.handle(command));
         verifyNoInteractions(fileStorageService);
     }
 
     @Test
-    @DisplayName("Should return bad request when filename is null")
-    void handle_nullFilename_returnsBadRequest() {
+    @DisplayName("Should throw FileValidationException when filename is null")
+    void handle_nullFilename_throwsFileValidationException() {
         when(mockFile.isEmpty()).thenReturn(false);
         when(mockFile.getOriginalFilename()).thenReturn(null);
         UploadFileCommand command = new UploadFileCommand(mockFile);
-
-        ApiResponse<Map<String, Object>> response = handler.handle(command);
-
-        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
-        assertEquals("Invalid filename", response.getMessage());
+        assertThrows(FileValidationException.class, () -> handler.handle(command));
         verifyNoInteractions(fileStorageService);
     }
 
     @Test
-    @DisplayName("Should return bad request when filename is blank")
-    void handle_blankFilename_returnsBadRequest() {
+    @DisplayName("Should throw FileValidationException when filename is blank")
+    void handle_blankFilename_throwsFileValidationException() {
         when(mockFile.isEmpty()).thenReturn(false);
         when(mockFile.getOriginalFilename()).thenReturn("   ");
         UploadFileCommand command = new UploadFileCommand(mockFile);
-
-        ApiResponse<Map<String, Object>> response = handler.handle(command);
-
-        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
-        assertEquals("Invalid filename", response.getMessage());
+        assertThrows(FileValidationException.class, () -> handler.handle(command));
         verifyNoInteractions(fileStorageService);
     }
 
     @Test
-    @DisplayName("Should return bad request when filename contains path traversal")
-    void handle_pathTraversalFilename_returnsBadRequest() {
+    @DisplayName("Should throw FileValidationException when filename contains path traversal")
+    void handle_pathTraversalFilename_throwsFileValidationException() {
         when(mockFile.isEmpty()).thenReturn(false);
         when(mockFile.getOriginalFilename()).thenReturn("../etc/passwd");
         UploadFileCommand command = new UploadFileCommand(mockFile);
-
-        ApiResponse<Map<String, Object>> response = handler.handle(command);
-
-        assertEquals(ResponseCode.BAD_REQUEST, response.getCode());
-        assertEquals("Invalid filename", response.getMessage());
+        assertThrows(FileValidationException.class, () -> handler.handle(command));
         verifyNoInteractions(fileStorageService);
     }
 
@@ -108,7 +89,6 @@ class UploadFileHandlerTest {
         ApiResponse<Map<String, Object>> response = handler.handle(command);
 
         assertEquals(ResponseCode.SUCCESS, response.getCode());
-        assertEquals("File uploaded successfully", response.getMessage());
         assertNotNull(response.getData());
         assertEquals(filename, response.getData().get("filename"));
         assertEquals("/api/v1/files/" + storedPath, response.getData().get("url"));
@@ -117,20 +97,14 @@ class UploadFileHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return error when file storage throws FileStorageException")
-    void handle_storageException_returnsError() {
-        String filename = "document.pdf";
-        String errorMessage = "Disk full";
-
+    @DisplayName("Should propagate FileStorageException when storage fails")
+    void handle_storageException_propagatesFileStorageException() {
         when(mockFile.isEmpty()).thenReturn(false);
-        when(mockFile.getOriginalFilename()).thenReturn(filename);
+        when(mockFile.getOriginalFilename()).thenReturn("document.pdf");
         when(fileStorageService.storeFile(mockFile, "uploads"))
-                .thenThrow(new FileStorageException(errorMessage));
+                .thenThrow(new FileStorageException("Disk full"));
 
         UploadFileCommand command = new UploadFileCommand(mockFile);
-        ApiResponse<Map<String, Object>> response = handler.handle(command);
-
-        assertEquals(ResponseCode.INTERNAL_SERVER_ERROR, response.getCode());
-        assertEquals("File upload failed: " + errorMessage, response.getMessage());
+        assertThrows(FileStorageException.class, () -> handler.handle(command));
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCodeTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCodeTest.java
@@ -1,0 +1,53 @@
+package com.iyte_yazilim.proje_pazari.application.common;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Guards the {@link ErrorCode} contract: every constant must carry a category and a message key
+ * that actually resolves to a non-blank, user-safe message in both supported locales. This catches
+ * the common mistake of adding an {@code ErrorCode} without its message-bundle entries.
+ */
+class ErrorCodeTest {
+
+    private static final Properties TR = load("/messages.properties");
+    private static final Properties EN = load("/messages_en.properties");
+
+    private static Properties load(String resource) {
+        Properties props = new Properties();
+        try (InputStream in = ErrorCodeTest.class.getResourceAsStream(resource)) {
+            assertNotNull(in, "Missing message bundle: " + resource);
+            props.load(new InputStreamReader(in, StandardCharsets.UTF_8));
+        } catch (IOException e) {
+            throw new AssertionError("Failed to load " + resource, e);
+        }
+        return props;
+    }
+
+    @ParameterizedTest
+    @EnumSource(ErrorCode.class)
+    @DisplayName("Every ErrorCode has a category and a non-blank message key in TR + EN bundles")
+    void errorCode_resolvesMessageKey_inBothLocales(ErrorCode errorCode) {
+        assertNotNull(errorCode.getCategory(), errorCode + " must have a category");
+
+        String key = errorCode.getMessageKey();
+        assertNotNull(key, errorCode + " must have a message key");
+
+        String tr = TR.getProperty(key);
+        String en = EN.getProperty(key);
+        assertTrue(
+                tr != null && !tr.isBlank(),
+                errorCode + " -> '" + key + "' missing or blank in messages.properties");
+        assertTrue(
+                en != null && !en.isBlank(),
+                errorCode + " -> '" + key + "' missing or blank in messages_en.properties");
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUser/GetUserHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUser/GetUserHandlerTest.java
@@ -5,11 +5,13 @@ import static org.mockito.Mockito.*;
 
 import com.github.f4b6a3.ulid.Ulid;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.common.ResponseCode;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.application.mappers.UserDtoMapper;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.entities.User;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers.UserMapper;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
@@ -88,21 +90,18 @@ class GetUserHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return not found when user does not exist")
-    void shouldReturnNotFound_whenUserDoesNotExist() {
+    @DisplayName("Should throw UserNotFoundException when user does not exist")
+    void shouldThrowNotFound_whenUserDoesNotExist() {
         // Given
         String userId = Ulid.fast().toString();
         GetUserQuery query = new GetUserQuery(userId);
 
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        // When
-        ApiResponse<UserDto> response = handler.handle(query);
-
-        // Then
-        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
-        assertEquals("User not found", response.getMessage());
-        assertNull(response.getData());
+        // When / Then
+        UserNotFoundException ex =
+                assertThrows(UserNotFoundException.class, () -> handler.handle(query));
+        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
         verify(userMapper, never()).entityToDomain(any());
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandlerTest.java
@@ -6,10 +6,12 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
 import com.iyte_yazilim.proje_pazari.application.common.ResponseCode;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserProfileDTO;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
@@ -97,21 +99,18 @@ class GetUserProfileHandlerTest {
     }
 
     @Test
-    @DisplayName("Should return not found when user does not exist")
-    void shouldReturnNotFound_whenUserDoesNotExist() {
+    @DisplayName("Should throw UserNotFoundException when user does not exist")
+    void shouldThrowNotFound_whenUserDoesNotExist() {
         // Given
         String userId = "nonexistent-user";
         GetUserProfileQuery query = new GetUserProfileQuery(userId);
 
         when(userRepository.findById(userId)).thenReturn(Optional.empty());
 
-        // When
-        ApiResponse<UserProfileDTO> response = handler.handle(query);
-
-        // Then
-        assertEquals(ResponseCode.NOT_FOUND, response.getCode());
-        assertTrue(response.getMessage().contains("not found"));
-        assertNull(response.getData());
+        // When / Then
+        UserNotFoundException ex =
+                assertThrows(UserNotFoundException.class, () -> handler.handle(query));
+        assertEquals(ErrorCode.USER_NOT_FOUND, ex.getErrorCode());
         verify(projectRepository, never()).findByOwnerId(any());
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ApplicationControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ApplicationControllerIntegrationTest.java
@@ -141,8 +141,8 @@ class ApplicationControllerIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
-        @DisplayName("3. Duplicate application returns 400 BAD_REQUEST")
-        void submitApplication_duplicate_returns400() throws Exception {
+        @DisplayName("3. Duplicate application returns 409 CONFLICT")
+        void submitApplication_duplicate_returns409() throws Exception {
             String ownerToken = createProjectOwnerAndGetToken();
             String projectId = createProjectAndGetId(ownerToken);
             String applicantToken = createApplicantAndGetToken(APPLICANT_EMAIL, "Mehmet");
@@ -159,7 +159,7 @@ class ApplicationControllerIntegrationTest extends IntegrationTestBase {
                             post(submitApplicationUrl(projectId))
                                     .header("Authorization", "Bearer " + applicantToken)
                                     .contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(status().isBadRequest());
+                    .andExpect(status().isConflict());
         }
 
         @Test

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ErrorHandlingIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ErrorHandlingIntegrationTest.java
@@ -1,5 +1,6 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
+import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -43,7 +44,7 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
     class ResponseFormatTests {
 
         @Test
-        @DisplayName("1. Error response contains code, message, and timestamp fields")
+        @DisplayName("1. Error response contains code, errorCode, message, and timestamp fields")
         void errorResponse_containsRequiredFields() throws Exception {
             mockMvc.perform(
                             post("/api/v1/auth/register")
@@ -51,6 +52,7 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
                                     .content("{}"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").exists())
+                    .andExpect(jsonPath("$.errorCode").value("VALIDATION_ERROR"))
                     .andExpect(jsonPath("$.message").exists())
                     .andExpect(jsonPath("$.timestamp").exists());
         }
@@ -157,11 +159,12 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
         }
 
         @Test
-        @DisplayName("5. Missing request parameter returns 400")
+        @DisplayName("5. Missing request parameter returns 400 with MISSING_PARAMETER errorCode")
         void refresh_missingParam_returns400() throws Exception {
             mockMvc.perform(post("/api/v1/auth/refresh"))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value(9));
+                    .andExpect(jsonPath("$.code").value(4))
+                    .andExpect(jsonPath("$.errorCode").value("MISSING_PARAMETER"));
         }
 
         @Test
@@ -256,20 +259,25 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
     class NotFoundTests {
 
         @Test
-        @DisplayName("1. Non-existent user profile returns 404 with NOT_FOUND code")
+        @DisplayName("1. Non-existent user profile returns 404 with USER_NOT_FOUND errorCode")
         void getUserProfile_nonExistent_returns404() throws Exception {
             mockMvc.perform(get("/api/v1/users/non-existent-user-id"))
                     .andExpect(status().isNotFound())
-                    .andExpect(jsonPath("$.code").value(7));
+                    .andExpect(jsonPath("$.code").value(7))
+                    .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"));
         }
 
         @Test
-        @DisplayName("2. Non-existent user returns 404 with message")
+        @DisplayName("2. Non-existent user returns 404 with a user-safe message (no leaked id)")
         void getUserProfile_nonExistent_returns404WithMessage() throws Exception {
             mockMvc.perform(get("/api/v1/users/another-non-existent-id"))
                     .andExpect(status().isNotFound())
                     .andExpect(jsonPath("$.code").value(7))
+                    .andExpect(jsonPath("$.errorCode").value("USER_NOT_FOUND"))
                     .andExpect(jsonPath("$.message").isNotEmpty())
+                    // Leak-regression guard: the looked-up id must never reach the client message.
+                    .andExpect(
+                            jsonPath("$.message", not(containsString("another-non-existent-id"))))
                     .andExpect(jsonPath("$.data").doesNotExist());
         }
     }
@@ -332,7 +340,8 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
                                                     new LoginUserCommand(
                                                             VALID_EMAIL, VALID_PASSWORD))))
                     .andExpect(status().isForbidden())
-                    .andExpect(jsonPath("$.code").value(6));
+                    .andExpect(jsonPath("$.code").value(6))
+                    .andExpect(jsonPath("$.errorCode").value("EMAIL_NOT_VERIFIED"));
         }
 
         @Test
@@ -342,7 +351,8 @@ class ErrorHandlingIntegrationTest extends IntegrationTestBase {
                             get("/api/v1/auth/verify-email")
                                     .param("token", "completely-invalid-token"))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.code").value(4));
+                    .andExpect(jsonPath("$.code").value(4))
+                    .andExpect(jsonPath("$.errorCode").value("INVALID_VERIFICATION_TOKEN"));
         }
     }
 


### PR DESCRIPTION
Closes #137.

## Problem

Error responses leaked technical detail (entity ids, emails, internal text) straight into the user-facing `message`. The only machine code was the coarse HTTP-bucket `ResponseCode` — `NOT_FOUND` covered user/project/application alike — so clients could not branch reliably.

## Changes

- **`ErrorCode`** — new stable, granular string enum. Each constant carries a `ResponseCode` category and an i18n message key.
- **`DomainException`** — new base exception carrying an `ErrorCode`; all 14 domain/application exceptions extend it. Technical messages are kept for logs only.
- **`ApiResponse`** — new `errorCode` field + `failure(ErrorCode, message)` factory. The numeric `code` field is **unchanged** for backward compatibility.
- **`GlobalExceptionHandler`** — the ~11 near-identical domain handlers collapse into one `DomainException` handler. Every handler now resolves a localized, user-safe message via `MessageService`; raw `ex.getMessage()` is never sent to the client. Added an `IllegalStateException` handler.
- **`GetUserHandler` / `GetUserProfileHandler`** — now throw `UserNotFoundException` instead of returning a hand-built `notFound` body (the old path also tried to concatenate the looked-up id into the message).
- **`ResponseCode.httpStatus()`** — status mapping now lives in one place.
- New i18n keys (TR + EN); Swagger error examples fixed to the real wire shape (numeric `code` + `errorCode`).

## Acceptance criteria

- [x] Error responses separate user-safe `message` from machine-readable `errorCode`
- [x] Technical/internal detail no longer exposed as user-facing messages (logs only)
- [x] Frontend can branch on a stable, granular code
- [x] Swagger output reflects the updated error shape
- [x] Existing behavior compatible — numeric `code` untouched
- [x] Tests added/updated

## Verification

- `./gradlew spotlessCheck` — clean
- `./gradlew test jacocoTestReport jacocoTestCoverageVerification` — 913 tests pass, coverage gate pass
- Tests add `errorCode` assertions, a leak-regression guard (ids never reach the client message), and a parametrized test that every `ErrorCode` resolves a non-blank message key in both locales.

## Frontend counterpart

IYTE-Yazilim-Toplulugu/proje-pazari#87