### PR TITLE
Fix/search status filter

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQuery.java
@@ -3,6 +3,8 @@ package com.iyte_yazilim.proje_pazari.application.queries.getAllProjects;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.application.dtos.PagedProjectsResult;
+import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 
-public record GetAllProjectsQuery(int page, int size, String sortBy, String sortDirection)
+public record GetAllProjectsQuery(
+        int page, int size, String sortBy, String sortDirection, ProjectStatus status)
         implements IRequest<ApiResponse<PagedProjectsResult>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandler.java
@@ -46,7 +46,11 @@ public class GetAllProjectsQueryHandler
         Pageable pageable = PageRequest.of(query.page(), query.size(), Sort.by(direction, sortBy));
 
         // --- 2. Fetch Paged Data from Repository ---
-        Page<ProjectEntity> projectEntityPage = projectRepository.findAllWithApplications(pageable);
+        Page<ProjectEntity> projectEntityPage =
+                query.status() == null
+                        ? projectRepository.findAllWithApplications(pageable)
+                        : projectRepository.findAllByStatusWithApplications(
+                                query.status(), pageable);
 
         // --- 3. Map Entity -> Domain -> DTO ---
         List<ProjectDetailDto> projectDtos =

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandler.java
@@ -47,10 +47,7 @@ public class GetAllProjectsQueryHandler
 
         // --- 2. Fetch Paged Data from Repository ---
         Page<ProjectEntity> projectEntityPage =
-                query.status() == null
-                        ? projectRepository.findAllWithApplications(pageable)
-                        : projectRepository.findAllByStatusWithApplications(
-                                query.status(), pageable);
+                projectRepository.findWithFilters(query.status(), null, null, pageable);
 
         // --- 3. Map Entity -> Domain -> DTO ---
         List<ProjectDetailDto> projectDtos =

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/ProjectRepository.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/ProjectRepository.java
@@ -40,14 +40,14 @@ public interface ProjectRepository extends JpaRepository<ProjectEntity, String> 
                             + "LEFT JOIN FETCH p.applications "
                             + "WHERE (:status IS NULL OR p.status = :status) AND "
                             + "(:ownerId IS NULL OR p.owner.id = :ownerId) AND "
-                            + "(:search IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :search, '%')) "
-                            + "OR LOWER(p.description) LIKE LOWER(CONCAT('%', :search, '%')))",
+                            + "(:search IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', CAST(:search AS string), '%')) "
+                            + "OR LOWER(p.description) LIKE LOWER(CONCAT('%', CAST(:search AS string), '%')))",
             countQuery =
                     "SELECT COUNT(p) FROM ProjectEntity p "
                             + "WHERE (:status IS NULL OR p.status = :status) AND "
                             + "(:ownerId IS NULL OR p.owner.id = :ownerId) AND "
-                            + "(:search IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', :search, '%')) "
-                            + "OR LOWER(p.description) LIKE LOWER(CONCAT('%', :search, '%')))")
+                            + "(:search IS NULL OR LOWER(p.title) LIKE LOWER(CONCAT('%', CAST(:search AS string), '%')) "
+                            + "OR LOWER(p.description) LIKE LOWER(CONCAT('%', CAST(:search AS string), '%')))")
     Page<ProjectEntity> findWithFilters(
             @Param("status") ProjectStatus status,
             @Param("ownerId") String ownerId,
@@ -61,14 +61,4 @@ public interface ProjectRepository extends JpaRepository<ProjectEntity, String> 
                             + "LEFT JOIN FETCH p.applications",
             countQuery = "SELECT COUNT(p) FROM ProjectEntity p")
     Page<ProjectEntity> findAllWithApplications(Pageable pageable);
-
-    @Query(
-            value =
-                    "SELECT p FROM ProjectEntity p "
-                            + "LEFT JOIN FETCH p.owner "
-                            + "LEFT JOIN FETCH p.applications "
-                            + "WHERE p.status = :status",
-            countQuery = "SELECT COUNT(p) FROM ProjectEntity p WHERE p.status = :status")
-    Page<ProjectEntity> findAllByStatusWithApplications(
-            @Param("status") ProjectStatus status, Pageable pageable);
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/ProjectRepository.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/ProjectRepository.java
@@ -61,4 +61,14 @@ public interface ProjectRepository extends JpaRepository<ProjectEntity, String> 
                             + "LEFT JOIN FETCH p.applications",
             countQuery = "SELECT COUNT(p) FROM ProjectEntity p")
     Page<ProjectEntity> findAllWithApplications(Pageable pageable);
+
+    @Query(
+            value =
+                    "SELECT p FROM ProjectEntity p "
+                            + "LEFT JOIN FETCH p.owner "
+                            + "LEFT JOIN FETCH p.applications "
+                            + "WHERE p.status = :status",
+            countQuery = "SELECT COUNT(p) FROM ProjectEntity p WHERE p.status = :status")
+    Page<ProjectEntity> findAllByStatusWithApplications(
+            @Param("status") ProjectStatus status, Pageable pageable);
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/config/GlobalExceptionHandler.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
 import org.springframework.web.multipart.MultipartException;
 
@@ -108,6 +109,15 @@ public class GlobalExceptionHandler {
         log.error("Missing request parameter: {}", ex.getMessage());
         ApiResponse<Void> response =
                 ApiResponse.validationError(messageService.getMessage("error.validation"));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException ex) {
+        log.error("Request parameter type mismatch: {}", ex.getMessage());
+        ApiResponse<Void> response =
+                ApiResponse.badRequest(messageService.getMessage("error.validation"));
         return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
     }
 

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectController.java
@@ -9,6 +9,7 @@ import com.iyte_yazilim.proje_pazari.application.dtos.PagedProjectsResult;
 import com.iyte_yazilim.proje_pazari.application.dtos.ProjectDetailDto;
 import com.iyte_yazilim.proje_pazari.application.queries.getAllProjects.GetAllProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.getProject.GetProjectQuery;
+import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 import com.iyte_yazilim.proje_pazari.domain.models.results.CreateProjectCommandResult;
 import com.iyte_yazilim.proje_pazari.domain.models.results.UpdateProjectStatusCommandResult;
 import io.swagger.v3.oas.annotations.Operation;
@@ -174,8 +175,9 @@ public class ProjectController extends BaseController {
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "id") String sortBy,
-            @RequestParam(defaultValue = "DESC") String sortDirection) {
-        return send(new GetAllProjectsQuery(page, size, sortBy, sortDirection));
+            @RequestParam(defaultValue = "DESC") String sortDirection,
+            @RequestParam(required = false) ProjectStatus status) {
+        return send(new GetAllProjectsQuery(page, size, sortBy, sortDirection, status));
     }
 
     @GetMapping("/{projectId}")

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandlerTest.java
@@ -11,6 +11,7 @@ import com.iyte_yazilim.proje_pazari.application.dtos.ProjectDetailDto;
 import com.iyte_yazilim.proje_pazari.application.mappers.ProjectDetailDtoMapper;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
 import com.iyte_yazilim.proje_pazari.domain.entities.Project;
+import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers.ProjectMapper;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
@@ -59,13 +60,35 @@ class GetAllProjectsQueryHandlerTest {
         when(projectDtoMapper.domainToDto(domain)).thenReturn(dto);
 
         ApiResponse<PagedProjectsResult> response =
-                handler.handle(new GetAllProjectsQuery(0, 10, "title", "ASC"));
+                handler.handle(new GetAllProjectsQuery(0, 10, "title", "ASC", null));
 
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertEquals(1, response.getData().projects().size());
         assertEquals(0, response.getData().currentPage());
         assertEquals(1, response.getData().totalPages());
         assertEquals(1L, response.getData().totalElements());
+        verify(projectRepository, never())
+                .findAllByStatusWithApplications(any(ProjectStatus.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("Should filter projects by status when status is provided")
+    void shouldFilterProjectsByStatus_whenStatusIsProvided() {
+        Page<ProjectEntity> emptyPage = new PageImpl<>(List.of());
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        when(projectRepository.findAllByStatusWithApplications(
+                        eq(ProjectStatus.OPEN), pageableCaptor.capture()))
+                .thenReturn(emptyPage);
+
+        ApiResponse<PagedProjectsResult> response =
+                handler.handle(
+                        new GetAllProjectsQuery(0, 10, "status", "DESC", ProjectStatus.OPEN));
+
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals(0, response.getData().currentPage());
+        assertEquals(0, response.getData().totalElements());
+        assertNotNull(pageableCaptor.getValue().getSort().getOrderFor("status"));
+        verify(projectRepository, never()).findAllWithApplications(any(Pageable.class));
     }
 
     @Test
@@ -76,7 +99,7 @@ class GetAllProjectsQueryHandlerTest {
         when(projectRepository.findAllWithApplications(pageableCaptor.capture()))
                 .thenReturn(emptyPage);
 
-        handler.handle(new GetAllProjectsQuery(0, 10, "invalidField", "ASC"));
+        handler.handle(new GetAllProjectsQuery(0, 10, "invalidField", "ASC", null));
 
         Pageable captured = pageableCaptor.getValue();
         Sort.Order order = captured.getSort().getOrderFor("id");
@@ -91,7 +114,7 @@ class GetAllProjectsQueryHandlerTest {
         when(projectRepository.findAllWithApplications(pageableCaptor.capture()))
                 .thenReturn(emptyPage);
 
-        handler.handle(new GetAllProjectsQuery(0, 10, "title", "DESC"));
+        handler.handle(new GetAllProjectsQuery(0, 10, "title", "DESC", null));
 
         Pageable captured = pageableCaptor.getValue();
         Sort.Order order = captured.getSort().getOrderFor("title");

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getAllProjects/GetAllProjectsQueryHandlerTest.java
@@ -55,7 +55,8 @@ class GetAllProjectsQueryHandlerTest {
                         null, null);
 
         Page<ProjectEntity> page = new PageImpl<>(List.of(entity));
-        when(projectRepository.findAllWithApplications(any(Pageable.class))).thenReturn(page);
+        when(projectRepository.findWithFilters(isNull(), isNull(), isNull(), any(Pageable.class)))
+                .thenReturn(page);
         when(projectMapper.entityToDomain(entity)).thenReturn(domain);
         when(projectDtoMapper.domainToDto(domain)).thenReturn(dto);
 
@@ -67,8 +68,6 @@ class GetAllProjectsQueryHandlerTest {
         assertEquals(0, response.getData().currentPage());
         assertEquals(1, response.getData().totalPages());
         assertEquals(1L, response.getData().totalElements());
-        verify(projectRepository, never())
-                .findAllByStatusWithApplications(any(ProjectStatus.class), any(Pageable.class));
     }
 
     @Test
@@ -76,8 +75,8 @@ class GetAllProjectsQueryHandlerTest {
     void shouldFilterProjectsByStatus_whenStatusIsProvided() {
         Page<ProjectEntity> emptyPage = new PageImpl<>(List.of());
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        when(projectRepository.findAllByStatusWithApplications(
-                        eq(ProjectStatus.OPEN), pageableCaptor.capture()))
+        when(projectRepository.findWithFilters(
+                        eq(ProjectStatus.OPEN), isNull(), isNull(), pageableCaptor.capture()))
                 .thenReturn(emptyPage);
 
         ApiResponse<PagedProjectsResult> response =
@@ -88,7 +87,6 @@ class GetAllProjectsQueryHandlerTest {
         assertEquals(0, response.getData().currentPage());
         assertEquals(0, response.getData().totalElements());
         assertNotNull(pageableCaptor.getValue().getSort().getOrderFor("status"));
-        verify(projectRepository, never()).findAllWithApplications(any(Pageable.class));
     }
 
     @Test
@@ -96,7 +94,8 @@ class GetAllProjectsQueryHandlerTest {
     void shouldDefaultSortById_whenSortByIsInvalid() {
         Page<ProjectEntity> emptyPage = new PageImpl<>(List.of());
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        when(projectRepository.findAllWithApplications(pageableCaptor.capture()))
+        when(projectRepository.findWithFilters(
+                        isNull(), isNull(), isNull(), pageableCaptor.capture()))
                 .thenReturn(emptyPage);
 
         handler.handle(new GetAllProjectsQuery(0, 10, "invalidField", "ASC", null));
@@ -111,7 +110,8 @@ class GetAllProjectsQueryHandlerTest {
     void shouldSortDescending_whenSortDirectionIsDesc() {
         Page<ProjectEntity> emptyPage = new PageImpl<>(List.of());
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
-        when(projectRepository.findAllWithApplications(pageableCaptor.capture()))
+        when(projectRepository.findWithFilters(
+                        isNull(), isNull(), isNull(), pageableCaptor.capture()))
                 .thenReturn(emptyPage);
 
         handler.handle(new GetAllProjectsQuery(0, 10, "title", "DESC", null));

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
@@ -435,6 +435,14 @@ class ProjectControllerIntegrationTest extends IntegrationTestBase {
                     .andExpect(jsonPath("$.data.totalElements").value(1));
         }
 
+        @Test
+        @DisplayName("5. Invalid status filter returns 400 BAD_REQUEST")
+        void getAllProjects_invalidStatus_returns400() throws Exception {
+            mockMvc.perform(get(BASE_URL).param("status", "BOGUS_VALUE"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.code").value(4));
+        }
+
         private ProjectEntity buildProject(String title, ProjectStatus status, UserEntity owner) {
             ProjectEntity project = new ProjectEntity();
             project.setTitle(title);

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
@@ -24,6 +24,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -420,27 +422,33 @@ class ProjectControllerIntegrationTest extends IntegrationTestBase {
             mockMvc.perform(get(BASE_URL)).andExpect(status().isOk());
         }
 
-        @Test
-        @DisplayName("4. Get all projects filters by status")
-        void getAllProjects_withStatus_returnsOnlyMatchingProjects() throws Exception {
+        @ParameterizedTest(name = "4. Get all projects filters by status {0}")
+        @EnumSource(ProjectStatus.class)
+        void getAllProjects_withStatus_returnsOnlyMatchingProjects(ProjectStatus status)
+                throws Exception {
             UserEntity owner = userRepository.findById(testUserId).orElseThrow();
-            projectRepository.save(buildProject("Open Project", ProjectStatus.OPEN, owner));
-            projectRepository.save(buildProject("Draft Project", ProjectStatus.DRAFT, owner));
+            String matchingTitle = status.name() + " Project";
+            projectRepository.save(buildProject(matchingTitle, status, owner));
+            projectRepository.save(buildProject("Other Project", differentStatus(status), owner));
 
-            mockMvc.perform(get(BASE_URL).param("status", "OPEN"))
+            mockMvc.perform(get(BASE_URL).param("status", status.name()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.projects.length()").value(1))
-                    .andExpect(jsonPath("$.data.projects[0].title").value("Open Project"))
-                    .andExpect(jsonPath("$.data.projects[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.data.projects[0].title").value(matchingTitle))
+                    .andExpect(jsonPath("$.data.projects[0].status").value(status.name()))
                     .andExpect(jsonPath("$.data.totalElements").value(1));
         }
 
         @Test
         @DisplayName("5. Invalid status filter returns 400 BAD_REQUEST")
         void getAllProjects_invalidStatus_returns400() throws Exception {
-            mockMvc.perform(get(BASE_URL).param("status", "BOGUS_VALUE"))
+            mockMvc.perform(get(BASE_URL).param("status", "INVALID_VALUE"))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.code").value(4));
+        }
+
+        private ProjectStatus differentStatus(ProjectStatus status) {
+            return status == ProjectStatus.OPEN ? ProjectStatus.DRAFT : ProjectStatus.OPEN;
         }
 
         private ProjectEntity buildProject(String title, ProjectStatus status, UserEntity owner) {

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
@@ -51,7 +51,7 @@ class ProjectControllerIntegrationTest extends IntegrationTestBase {
     // ── Helper Methods ──────────────────────────────────────────────────
 
     @BeforeEach
-    void setUp() {
+    void createDefaultUser() {
         UserEntity user = new UserEntity();
         user.setEmail("projcontroller-" + System.nanoTime() + "@std.iyte.edu.tr");
         user.setPassword(passwordEncoder.encode("TestPassword123!"));

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ProjectControllerIntegrationTest.java
@@ -10,12 +10,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
+import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.ProjectRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.EmailVerificationEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
 import com.iyte_yazilim.proje_pazari.presentation.security.JwtUtil;
 import java.time.LocalDateTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -415,6 +418,35 @@ class ProjectControllerIntegrationTest extends IntegrationTestBase {
         @DisplayName("3. Get all projects is accessible without authentication")
         void getAllProjects_noAuth_returns200() throws Exception {
             mockMvc.perform(get(BASE_URL)).andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("4. Get all projects filters by status")
+        void getAllProjects_withStatus_returnsOnlyMatchingProjects() throws Exception {
+            UserEntity owner = userRepository.findById(testUserId).orElseThrow();
+            projectRepository.save(buildProject("Open Project", ProjectStatus.OPEN, owner));
+            projectRepository.save(buildProject("Draft Project", ProjectStatus.DRAFT, owner));
+
+            mockMvc.perform(get(BASE_URL).param("status", "OPEN"))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.projects.length()").value(1))
+                    .andExpect(jsonPath("$.data.projects[0].title").value("Open Project"))
+                    .andExpect(jsonPath("$.data.projects[0].status").value("OPEN"))
+                    .andExpect(jsonPath("$.data.totalElements").value(1));
+        }
+
+        private ProjectEntity buildProject(String title, ProjectStatus status, UserEntity owner) {
+            ProjectEntity project = new ProjectEntity();
+            project.setTitle(title);
+            project.setDescription("Project used for status filtering integration coverage.");
+            project.setSummary(title);
+            project.setStatus(status);
+            project.setOwner(owner);
+            project.setApplications(List.of());
+            project.setMaxTeamSize(5);
+            project.setRequiredSkills(List.of("Java", "Spring Boot"));
+            project.setCategory("Backend");
+            return project;
         }
     }
 


### PR DESCRIPTION
## Summary

  Fixes the `status` filter on `GET /api/v1/projects`.

  The endpoint previously accepted requests like `GET /api/v1/projects?status=OPEN`, but the controller did not bind the `status` query parameter, and `GetAllProjectsQuery` did not carry it to the handler. As
  a result, the handler always called the unfiltered repository method and returned all projects.

  ## Changes

  - Added optional `ProjectStatus status` query parameter to `GET /api/v1/projects`
  - Added `status` to `GetAllProjectsQuery`
  - Updated `GetAllProjectsQueryHandler` to:
    - keep existing behavior when `status` is not provided
    - call a status-filtered repository query when `status` is provided
  - Added a dedicated repository method for fetching projects by status with pagination
  - Added unit and integration tests for status filtering

  ## Testing

  - `./gradlew spotlessCheck`
  - `./gradlew test --tests com.iyte_yazilim.proje_pazari.application.queries.getAllProjects.GetAllProjectsQueryHandlerTest --tests
  com.iyte_yazilim.proje_pazari.presentation.controllers.ProjectControllerIntegrationTest`

  ## Closes

  Closes #130
