### PR TITLE
Fix/search response project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - ProjectStatus default initialization issue
+- Project search response now matches the regular project list shape (flat `ownerId`/`ownerName`/`ownerEmail`, `applicationCount`); requires a post-deploy reindex of the `projects` index (see `docs/DEPLOYMENT.md` → Elasticsearch Index Management)
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - HTTP method changed from `POST` to `PUT` for semantic correctness (update operation)
   - Existing clients using `POST` will receive `405 Method Not Allowed`
 
+### Removed
+
+- **[BREAKING]** Removed the unused `tags` field from project search and the `?tags=` filter on `GET /api/v1/search/projects` (per #128 — `tags` was never persisted and produced a misleading API contract). Filtering is now limited to `status`; the response continues to expose `requiredSkills`. Requires the same post-deploy reindex of the `projects` index noted below.
+
 ### Fixed
 
 - ProjectStatus default initialization issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ProjectStatus default initialization issue
 - Project search response now matches the regular project list shape (flat `ownerId`/`ownerName`/`ownerEmail`, `applicationCount`); requires a post-deploy reindex of the `projects` index (see `docs/DEPLOYMENT.md` → Elasticsearch Index Management)
+- Search no longer returns HTTP 500 when an indexed document carries an unrecognized status value — unknown statuses now degrade to `null`
 
 ### Security
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -251,6 +251,39 @@ spring.flyway.baseline-on-migrate=true
 
 ---
 
+## Elasticsearch Index Management
+
+Project and user search are backed by Elasticsearch documents (`ProjectDocument`,
+`UserDocument`) that are denormalized copies of the PostgreSQL data. The index mappings are
+auto-created from the `@Field` annotations at startup, but existing documents are **not**
+rewritten when those annotations change.
+
+### Post-Deploy Reindex (required after a document shape/mapping change)
+
+Whenever a release changes the shape of a search document — renaming/adding/removing fields,
+flattening nested objects, or changing a `@Field` type/analyzer — pre-existing documents stay
+in the **old** shape. Until they are rewritten, search hits deserialize with the old layout
+(missing or null fields), so the change appears not to work for already-indexed records.
+
+After such a deploy, once the smoke test passes, trigger a full reindex. The endpoint drops the
+index and rebuilds it from PostgreSQL (runs asynchronously):
+
+```bash
+# Projects (ADMIN role + Bearer token required)
+curl -X POST https://api.projepazari.site/api/v1/admin/elasticsearch/reindex/projects \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+
+# Users (only when the user document shape changed)
+curl -X POST https://api.projepazari.site/api/v1/admin/elasticsearch/reindex/users \
+  -H "Authorization: Bearer $ADMIN_TOKEN"
+```
+
+> [!NOTE]
+> The CD pipeline does **not** reindex automatically — this is a manual post-deploy step.
+> Monitor the application logs for completion since the reindex is `@Async`.
+
+---
+
 ## Health Checks
 
 ### Built-in Endpoints

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
@@ -59,7 +59,7 @@ public class SearchProjectsHandler
                 document.getDescription(),
                 document.getSummary(),
                 document.getApplicationCount(),
-                document.getStatus() != null ? ProjectStatus.valueOf(document.getStatus()) : null,
+                ProjectStatus.fromString(document.getStatus()),
                 document.getMaxTeamSize(),
                 document.getRequiredSkills() != null ? document.getRequiredSkills() : List.of(),
                 document.getCategory(),

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
@@ -31,7 +31,7 @@ public class SearchProjectsHandler
     public ApiResponse<PagedProjectsResult> handle(SearchProjectsQuery query) {
         Pageable pageable = PageRequest.of(query.page(), query.size());
         SearchPage<ProjectDocument> results =
-                searchService.advancedSearch(query.q(), query.status(), query.tags(), pageable);
+                searchService.advancedSearch(query.q(), query.status(), pageable);
 
         List<ProjectDetailDto> projects =
                 results.getContent().stream()

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandler.java
@@ -2,7 +2,10 @@ package com.iyte_yazilim.proje_pazari.application.queries.searchProjects;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
+import com.iyte_yazilim.proje_pazari.application.dtos.PagedProjectsResult;
+import com.iyte_yazilim.proje_pazari.application.dtos.ProjectDetailDto;
 import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -20,19 +23,47 @@ import org.springframework.stereotype.Component;
         havingValue = "true",
         matchIfMissing = true)
 public class SearchProjectsHandler
-        implements IRequestHandler<SearchProjectsQuery, ApiResponse<List<ProjectDocument>>> {
+        implements IRequestHandler<SearchProjectsQuery, ApiResponse<PagedProjectsResult>> {
 
     private final ProjectSearchService searchService;
 
     @Override
-    public ApiResponse<List<ProjectDocument>> handle(SearchProjectsQuery query) {
+    public ApiResponse<PagedProjectsResult> handle(SearchProjectsQuery query) {
         Pageable pageable = PageRequest.of(query.page(), query.size());
         SearchPage<ProjectDocument> results =
                 searchService.advancedSearch(query.q(), query.status(), query.tags(), pageable);
 
-        List<ProjectDocument> documents =
-                results.getContent().stream().map(SearchHit::getContent).toList();
+        List<ProjectDetailDto> projects =
+                results.getContent().stream()
+                        .map(SearchHit::getContent)
+                        .map(this::toProjectDetailDto)
+                        .toList();
 
-        return ApiResponse.success(documents, "Projects retrieved successfully");
+        PagedProjectsResult response =
+                new PagedProjectsResult(
+                        projects,
+                        results.getNumber(),
+                        results.getTotalPages(),
+                        results.getTotalElements());
+
+        return ApiResponse.success(response, "Projects retrieved successfully");
+    }
+
+    private ProjectDetailDto toProjectDetailDto(ProjectDocument document) {
+        return new ProjectDetailDto(
+                document.getId(),
+                document.getOwnerId(),
+                document.getOwnerName(),
+                document.getOwnerEmail(),
+                document.getTitle(),
+                document.getDescription(),
+                document.getSummary(),
+                document.getApplicationCount(),
+                document.getStatus() != null ? ProjectStatus.valueOf(document.getStatus()) : null,
+                document.getMaxTeamSize(),
+                document.getRequiredSkills() != null ? document.getRequiredSkills() : List.of(),
+                document.getCategory(),
+                document.getDeadline(),
+                document.getCreatedAt());
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsQuery.java
@@ -2,7 +2,7 @@ package com.iyte_yazilim.proje_pazari.application.queries.searchProjects;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
+import com.iyte_yazilim.proje_pazari.application.dtos.PagedProjectsResult;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -15,4 +15,4 @@ public record SearchProjectsQuery(
         List<String> tags,
         @Min(0) int page,
         @Min(1) @Max(100) int size)
-        implements IRequest<ApiResponse<List<ProjectDocument>>> {}
+        implements IRequest<ApiResponse<PagedProjectsResult>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsQuery.java
@@ -7,12 +7,10 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import java.util.List;
 
 public record SearchProjectsQuery(
         @NotBlank @Size(min = 2, max = 100) String q,
         String status,
-        List<String> tags,
         @Min(0) int page,
         @Min(1) @Max(100) int size)
         implements IRequest<ApiResponse<PagedProjectsResult>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/services/ProjectSearchService.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/services/ProjectSearchService.java
@@ -62,7 +62,7 @@ public class ProjectSearchService {
 
     // Changed from Page to SearchPage
     public SearchPage<ProjectDocument> advancedSearch(
-            String keyword, String status, List<String> tags, Pageable pageable) {
+            String keyword, String status, Pageable pageable) {
 
         // Build bool query with multiple conditions
         Query query =
@@ -100,33 +100,6 @@ public class ProjectSearchService {
                                                                                                         "status")
                                                                                                 .value(
                                                                                                         status)));
-                                                    }
-
-                                                    // Add tags filter if provided
-                                                    if (tags != null && !tags.isEmpty()) {
-                                                        b.filter(
-                                                                f ->
-                                                                        f.terms(
-                                                                                t ->
-                                                                                        t.field(
-                                                                                                        "tags")
-                                                                                                .terms(
-                                                                                                        ts ->
-                                                                                                                ts
-                                                                                                                        .value(
-                                                                                                                                tags
-                                                                                                                                        .stream()
-                                                                                                                                        .map(
-                                                                                                                                                tag ->
-                                                                                                                                                        co
-                                                                                                                                                                .elastic
-                                                                                                                                                                .clients
-                                                                                                                                                                .elasticsearch
-                                                                                                                                                                ._types
-                                                                                                                                                                .FieldValue
-                                                                                                                                                                .of(
-                                                                                                                                                                        tag))
-                                                                                                                                        .toList()))));
                                                     }
 
                                                     return b;

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/enums/ProjectStatus.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/enums/ProjectStatus.java
@@ -30,5 +30,27 @@ public enum ProjectStatus {
     COMPLETED,
 
     /** Project has been cancelled or abandoned. */
-    CANCELLED
+    CANCELLED;
+
+    /**
+     * Safely parses a status string into a {@link ProjectStatus}, returning {@code null} instead of
+     * throwing when the value is {@code null} or does not match any known status.
+     *
+     * <p>Useful when reading status values from external/denormalized sources (e.g. Elasticsearch
+     * documents) where a stale or unexpected value should degrade gracefully rather than fail the
+     * whole request.
+     *
+     * @param value the status string to parse, may be {@code null}
+     * @return the matching {@link ProjectStatus}, or {@code null} if unknown or {@code null}
+     */
+    public static ProjectStatus fromString(String value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return valueOf(value);
+        } catch (IllegalArgumentException e) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/ProjectDocumentMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/ProjectDocumentMapper.java
@@ -23,6 +23,5 @@ public interface ProjectDocumentMapper {
             target = "applicationCount",
             expression =
                     "java(entity.getApplications() != null ? entity.getApplications().size() : 0)")
-    @Mapping(target = "tags", source = "requiredSkills")
     ProjectDocument toDocument(ProjectEntity entity);
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/ProjectDocumentMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/ProjectDocumentMapper.java
@@ -1,13 +1,9 @@
 package com.iyte_yazilim.proje_pazari.infrastructure.persistence.mappers;
 
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument.OwnerInfo;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectEntity;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
-import com.iyte_yazilim.proje_pazari.infrastructure.utils.NameUtils;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Named;
 
 @Mapper(componentModel = "spring")
 public interface ProjectDocumentMapper {
@@ -15,23 +11,18 @@ public interface ProjectDocumentMapper {
     @Mapping(
             target = "status",
             expression = "java(entity.getStatus() != null ? entity.getStatus().name() : null)")
-    @Mapping(target = "owner", source = "owner", qualifiedByName = "toOwnerInfo")
+    @Mapping(target = "ownerId", source = "owner.id")
     @Mapping(
-            target = "applicationsCount",
+            target = "ownerName",
+            expression =
+                    "java(entity.getOwner() != null ? com.iyte_yazilim.proje_pazari.infrastructure.utils.NameUtils.buildFullName(entity.getOwner().getFirstName(), entity.getOwner().getLastName()) : null)")
+    @Mapping(
+            target = "ownerEmail",
+            expression = "java(entity.getOwner() != null ? entity.getOwner().getEmail() : null)")
+    @Mapping(
+            target = "applicationCount",
             expression =
                     "java(entity.getApplications() != null ? entity.getApplications().size() : 0)")
-    @Mapping(target = "tags", ignore = true)
+    @Mapping(target = "tags", source = "requiredSkills")
     ProjectDocument toDocument(ProjectEntity entity);
-
-    @Named("toOwnerInfo")
-    default OwnerInfo toOwnerInfo(UserEntity user) {
-        if (user == null) {
-            return null;
-        }
-        OwnerInfo ownerInfo = new OwnerInfo();
-        ownerInfo.setId(user.getId());
-        ownerInfo.setEmail(user.getEmail());
-        ownerInfo.setName(NameUtils.buildFullName(user.getFirstName(), user.getLastName()));
-        return ownerInfo;
-    }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/ProjectDocument.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/ProjectDocument.java
@@ -49,9 +49,6 @@ public class ProjectDocument {
     @Field(type = FieldType.Keyword)
     private String ownerEmail;
 
-    @Field(type = FieldType.Keyword)
-    private List<String> tags;
-
     @Field(type = FieldType.Integer)
     private Integer maxTeamSize;
 

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/ProjectDocument.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/ProjectDocument.java
@@ -4,7 +4,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -41,11 +40,26 @@ public class ProjectDocument {
     @Field(type = FieldType.Keyword)
     private String category;
 
-    @Field(type = FieldType.Nested)
-    private OwnerInfo owner;
+    @Field(type = FieldType.Keyword)
+    private String ownerId;
+
+    @Field(type = FieldType.Text)
+    private String ownerName;
+
+    @Field(type = FieldType.Keyword)
+    private String ownerEmail;
 
     @Field(type = FieldType.Keyword)
     private List<String> tags;
+
+    @Field(type = FieldType.Integer)
+    private Integer maxTeamSize;
+
+    @Field(type = FieldType.Keyword)
+    private List<String> requiredSkills;
+
+    @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_fraction)
+    private LocalDateTime deadline;
 
     @Field(type = FieldType.Date, format = DateFormat.date_hour_minute_second_fraction)
     private LocalDateTime createdAt;
@@ -54,17 +68,5 @@ public class ProjectDocument {
     private LocalDateTime updatedAt;
 
     @Field(type = FieldType.Integer)
-    private int applicationsCount;
-
-    @Data
-    public static class OwnerInfo {
-        @Field(type = FieldType.Keyword)
-        private String id;
-
-        @Field(type = FieldType.Text)
-        private String name;
-
-        @Field(type = FieldType.Keyword)
-        private String email;
-    }
+    private int applicationCount;
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
@@ -1,10 +1,10 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.dtos.PagedProjectsResult;
 import com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics.GetProjectStatisticsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.searchProjects.SearchProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.suggestProjects.SuggestProjectsQuery;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -48,7 +48,7 @@ public class SearchController extends BaseController {
                         responseCode = "400",
                         description = "Invalid search parameters")
             })
-    public ResponseEntity<ApiResponse<List<ProjectDocument>>> searchProjects(
+    public ResponseEntity<ApiResponse<PagedProjectsResult>> searchProjects(
             @Parameter(
                             description = "Search query string",
                             required = true,

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchController.java
@@ -38,7 +38,7 @@ public class SearchController extends BaseController {
             summary = "Search projects",
             description =
                     "Full-text search across projects using Elasticsearch. "
-                            + "Supports filtering by status and tags with pagination.")
+                            + "Supports filtering by status with pagination.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -63,15 +63,12 @@ public class SearchController extends BaseController {
                             example = "OPEN")
                     @RequestParam(required = false)
                     String status,
-            @Parameter(description = "Filter by tags (multiple allowed)", example = "python")
-                    @RequestParam(required = false)
-                    List<String> tags,
             @Parameter(description = "Page number (zero-based)", example = "0")
                     @RequestParam(defaultValue = "0")
                     int page,
             @Parameter(description = "Page size", example = "10") @RequestParam(defaultValue = "10")
                     int size) {
-        return send(new SearchProjectsQuery(q, status, tags, page, size));
+        return send(new SearchProjectsQuery(q, status, page, size));
     }
 
     @GetMapping("/projects/suggest")

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/searchProjects/SearchProjectsHandlerTest.java
@@ -1,0 +1,89 @@
+package com.iyte_yazilim.proje_pazari.application.queries.searchProjects;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
+import com.iyte_yazilim.proje_pazari.application.dtos.PagedProjectsResult;
+import com.iyte_yazilim.proje_pazari.application.dtos.ProjectDetailDto;
+import com.iyte_yazilim.proje_pazari.application.services.ProjectSearchService;
+import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.elasticsearch.core.SearchHit;
+import org.springframework.data.elasticsearch.core.SearchPage;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("SearchProjectsHandler Tests")
+class SearchProjectsHandlerTest {
+
+    @Mock private ProjectSearchService searchService;
+
+    @InjectMocks private SearchProjectsHandler handler;
+
+    private SearchProjectsQuery query() {
+        return new SearchProjectsQuery("test", null, 0, 10);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void mockSearchReturns(ProjectDocument document) {
+        SearchHit<ProjectDocument> hit =
+                (SearchHit<ProjectDocument>) org.mockito.Mockito.mock(SearchHit.class);
+        when(hit.getContent()).thenReturn(document);
+
+        SearchPage<ProjectDocument> page =
+                (SearchPage<ProjectDocument>) org.mockito.Mockito.mock(SearchPage.class);
+        when(page.getContent()).thenReturn(List.of(hit));
+        when(page.getNumber()).thenReturn(0);
+        when(page.getTotalPages()).thenReturn(1);
+        when(page.getTotalElements()).thenReturn(1L);
+
+        when(searchService.advancedSearch(eq("test"), any(), any())).thenReturn(page);
+    }
+
+    @Test
+    @DisplayName("Should map a valid status string to the matching enum")
+    void shouldMapValidStatus() {
+        mockSearchReturns(ProjectDocument.builder().id("1").status("OPEN").build());
+
+        ApiResponse<PagedProjectsResult> response = handler.handle(query());
+
+        ProjectDetailDto dto = response.getData().projects().get(0);
+        assertThat(dto.status()).isEqualTo(ProjectStatus.OPEN);
+    }
+
+    @Test
+    @DisplayName("Should degrade an unknown status to null without failing the search")
+    void shouldDegradeUnknownStatusToNull() {
+        mockSearchReturns(ProjectDocument.builder().id("1").status("INVALID_STATUS").build());
+
+        ApiResponse<PagedProjectsResult> response = handler.handle(query());
+
+        ProjectDetailDto dto = response.getData().projects().get(0);
+        assertThat(dto.status()).isNull();
+    }
+
+    @Test
+    @DisplayName("Should map a null status to null without throwing")
+    void shouldMapNullStatusToNull() {
+        ProjectDocument document = ProjectDocument.builder().id("1").status(null).build();
+
+        assertThatCode(
+                        () -> {
+                            mockSearchReturns(document);
+                            ProjectDetailDto dto =
+                                    handler.handle(query()).getData().projects().get(0);
+                            assertThat(dto.status()).isNull();
+                        })
+                .doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/services/ProjectSearchServiceIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/services/ProjectSearchServiceIntegrationTest.java
@@ -68,7 +68,7 @@ class ProjectSearchServiceIntegrationTest {
                         .tags(null)
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
-                        .applicationsCount(5)
+                        .applicationCount(5)
                         .build();
 
         ProjectDocument project2 =
@@ -81,7 +81,7 @@ class ProjectSearchServiceIntegrationTest {
                         .tags(null)
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
-                        .applicationsCount(3)
+                        .applicationCount(3)
                         .build();
 
         ProjectDocument project3 =
@@ -94,7 +94,7 @@ class ProjectSearchServiceIntegrationTest {
                         .tags(null)
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
-                        .applicationsCount(10)
+                        .applicationCount(10)
                         .build();
 
         elasticsearchOperations.save(project1);

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/services/ProjectSearchServiceIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/services/ProjectSearchServiceIntegrationTest.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,9 +54,6 @@ class ProjectSearchServiceIntegrationTest {
         elasticsearchOperations.indexOps(ProjectDocument.class).create();
         elasticsearchOperations.indexOps(ProjectDocument.class).putMapping();
 
-        // Note: tags are set to null to reflect actual behavior - the ProjectDocumentMapper
-        // ignores tags (see @Mapping(target = "tags", ignore = true)). Tag functionality
-        // is not yet implemented in the mapper.
         ProjectDocument project1 =
                 ProjectDocument.builder()
                         .id("1")
@@ -65,7 +61,6 @@ class ProjectSearchServiceIntegrationTest {
                         .description("A comprehensive Spring Boot application")
                         .summary("Backend development with Java")
                         .status("ACTIVE")
-                        .tags(null)
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
                         .applicationCount(5)
@@ -78,7 +73,6 @@ class ProjectSearchServiceIntegrationTest {
                         .description("Modern React application with TypeScript")
                         .summary("Frontend development with React")
                         .status("ACTIVE")
-                        .tags(null)
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
                         .applicationCount(3)
@@ -91,7 +85,6 @@ class ProjectSearchServiceIntegrationTest {
                         .description("ML project using Python and TensorFlow")
                         .summary("Data science and machine learning")
                         .status("COMPLETED")
-                        .tags(null)
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
                         .applicationCount(10)
@@ -135,7 +128,7 @@ class ProjectSearchServiceIntegrationTest {
     @DisplayName("Should return results for advanced search with keyword filter")
     void shouldPerformAdvancedSearchWithKeyword() {
         SearchPage<ProjectDocument> results =
-                projectSearchService.advancedSearch("Java", null, null, PageRequest.of(0, 10));
+                projectSearchService.advancedSearch("Java", null, PageRequest.of(0, 10));
 
         assertThat(results.getSearchHits().getTotalHits()).isGreaterThan(0);
     }
@@ -144,21 +137,9 @@ class ProjectSearchServiceIntegrationTest {
     @DisplayName("Should return only projects matching the given status in advanced search")
     void shouldPerformAdvancedSearchWithStatus() {
         SearchPage<ProjectDocument> results =
-                projectSearchService.advancedSearch(null, "COMPLETED", null, PageRequest.of(0, 10));
+                projectSearchService.advancedSearch(null, "COMPLETED", PageRequest.of(0, 10));
 
         assertThat(results.getSearchHits().getTotalHits()).isEqualTo(1);
-    }
-
-    @Test
-    @Disabled(
-            "Tag search functionality not yet implemented - tags are ignored in ProjectDocumentMapper")
-    @DisplayName("Should return results matching given tags in advanced search")
-    void shouldPerformAdvancedSearchWithTags() {
-        SearchPage<ProjectDocument> results =
-                projectSearchService.advancedSearch(
-                        null, null, List.of("java"), PageRequest.of(0, 10));
-
-        assertThat(results.getSearchHits().getTotalHits()).isGreaterThan(0);
     }
 
     @Test

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
@@ -114,7 +114,6 @@ class SearchControllerTest {
                         .ownerId("owner-1")
                         .ownerName("Jane Smith")
                         .ownerEmail("jane@example.com")
-                        .tags(List.of("python", "ml", "data"))
                         .requiredSkills(List.of("python", "ml", "data"))
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
@@ -131,7 +130,6 @@ class SearchControllerTest {
                         .ownerId("owner-2")
                         .ownerName("John Smith")
                         .ownerEmail("john@example.com")
-                        .tags(List.of("react", "javascript"))
                         .requiredSkills(List.of("react", "javascript"))
                         .createdAt(LocalDateTime.now().minusDays(10))
                         .updatedAt(LocalDateTime.now().minusDays(5))
@@ -260,47 +258,7 @@ class SearchControllerTest {
 
         @Test
         @WithMockUser
-        @DisplayName("3. Filter by multiple tags passes tags to query")
-        void search_filterByMultipleTags_passesTagsToQuery() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(searchResponse(projectWithTitle));
-
-            mockMvc.perform(
-                            get("/api/v1/search/projects")
-                                    .param("q", "project")
-                                    .param("tags", "python", "ml"))
-                    .andExpect(status().isOk());
-
-            ArgumentCaptor<SearchProjectsQuery> captor =
-                    ArgumentCaptor.forClass(SearchProjectsQuery.class);
-            verify(mediator).send(captor.capture());
-            assertThat(captor.getValue().tags()).contains("python", "ml").hasSize(2);
-        }
-
-        @Test
-        @WithMockUser
-        @DisplayName("4. Filter by status and tags combined passes both to query")
-        void search_filterByStatusAndTags_passesBoth() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(searchResponse(projectWithTitle));
-
-            mockMvc.perform(
-                            get("/api/v1/search/projects")
-                                    .param("q", "project")
-                                    .param("status", "OPEN")
-                                    .param("tags", "python"))
-                    .andExpect(status().isOk());
-
-            ArgumentCaptor<SearchProjectsQuery> captor =
-                    ArgumentCaptor.forClass(SearchProjectsQuery.class);
-            verify(mediator).send(captor.capture());
-            assertThat(captor.getValue().status()).isEqualTo("OPEN");
-            assertThat(captor.getValue().tags()).contains("python");
-        }
-
-        @Test
-        @WithMockUser
-        @DisplayName("5. Search without filters uses default values")
+        @DisplayName("3. Search without filters uses default values")
         void search_noFilters_usesDefaults() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
                     .thenReturn(searchResponse(projectWithTitle));
@@ -314,7 +272,6 @@ class SearchControllerTest {
             assertThat(captor.getValue().page()).isZero();
             assertThat(captor.getValue().size()).isEqualTo(10);
             assertThat(captor.getValue().status()).isNull();
-            assertThat(captor.getValue().tags()).isNull();
         }
     }
 
@@ -409,8 +366,8 @@ class SearchControllerTest {
 
         @Test
         @WithMockUser
-        @DisplayName("2. Search results have correct tag values")
-        void search_results_haveCorrectTags() throws Exception {
+        @DisplayName("2. Search results have correct requiredSkills values")
+        void search_results_haveCorrectRequiredSkills() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
                     .thenReturn(searchResponse(projectWithTitle));
 
@@ -465,8 +422,7 @@ class SearchControllerTest {
             mockMvc.perform(
                             get("/api/v1/search/projects")
                                     .param("q", "project")
-                                    .param("status", "DRAFT")
-                                    .param("tags", "nonexistent-tag"))
+                                    .param("status", "DRAFT"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.data.projects").isEmpty());
         }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
@@ -11,10 +11,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IMediator;
+import com.iyte_yazilim.proje_pazari.application.dtos.PagedProjectsResult;
+import com.iyte_yazilim.proje_pazari.application.dtos.ProjectDetailDto;
 import com.iyte_yazilim.proje_pazari.application.queries.getProjectStatistics.GetProjectStatisticsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.searchProjects.SearchProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.queries.suggestProjects.SuggestProjectsQuery;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.enums.ProjectStatus;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.ProjectDocument;
 import com.iyte_yazilim.proje_pazari.presentation.mappers.IRequestMapper;
@@ -107,11 +110,15 @@ class SearchControllerTest {
                         .title("Machine Learning Pipeline")
                         .description("A data processing pipeline")
                         .summary("ML project for data engineering")
-                        .status("ACTIVE")
+                        .status("OPEN")
+                        .ownerId("owner-1")
+                        .ownerName("Jane Smith")
+                        .ownerEmail("jane@example.com")
                         .tags(List.of("python", "ml", "data"))
+                        .requiredSkills(List.of("python", "ml", "data"))
                         .createdAt(LocalDateTime.now())
                         .updatedAt(LocalDateTime.now())
-                        .applicationsCount(3)
+                        .applicationCount(3)
                         .build();
 
         projectWithDescription =
@@ -121,10 +128,14 @@ class SearchControllerTest {
                         .description("A comprehensive React frontend with machine learning backend")
                         .summary("Full-stack web app")
                         .status("COMPLETED")
+                        .ownerId("owner-2")
+                        .ownerName("John Smith")
+                        .ownerEmail("john@example.com")
                         .tags(List.of("react", "javascript"))
+                        .requiredSkills(List.of("react", "javascript"))
                         .createdAt(LocalDateTime.now().minusDays(10))
                         .updatedAt(LocalDateTime.now().minusDays(5))
-                        .applicationsCount(8)
+                        .applicationCount(8)
                         .build();
     }
 
@@ -139,15 +150,14 @@ class SearchControllerTest {
         @DisplayName("1. Search keyword matching title returns matching projects")
         void search_keywordInTitle_returnsMatches() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "Machine Learning"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data[0].title").value("Machine Learning Pipeline"))
-                    .andExpect(jsonPath("$.data[0].id").value("1"));
+                    .andExpect(jsonPath("$.data.projects").isArray())
+                    .andExpect(
+                            jsonPath("$.data.projects[0].title").value("Machine Learning Pipeline"))
+                    .andExpect(jsonPath("$.data.projects[0].id").value("1"));
         }
 
         @Test
@@ -155,13 +165,13 @@ class SearchControllerTest {
         @DisplayName("2. Search with partial title match returns results")
         void search_partialTitle_returnsMatches() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "Pipeline"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].title").value("Machine Learning Pipeline"));
+                    .andExpect(
+                            jsonPath("$.data.projects[0].title")
+                                    .value("Machine Learning Pipeline"));
         }
     }
 
@@ -176,17 +186,14 @@ class SearchControllerTest {
         @DisplayName("1. Search keyword matching description returns matching projects")
         void search_keywordInDescription_returnsMatches() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithDescription),
-                                    "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithDescription));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "React frontend"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data[0].title").value("Web Application"))
+                    .andExpect(jsonPath("$.data.projects").isArray())
+                    .andExpect(jsonPath("$.data.projects[0].title").value("Web Application"))
                     .andExpect(
-                            jsonPath("$.data[0].description")
+                            jsonPath("$.data.projects[0].description")
                                     .value(
                                             "A comprehensive React frontend with machine learning backend"));
         }
@@ -196,15 +203,12 @@ class SearchControllerTest {
         @DisplayName("2. Search returns results from both title and description matches")
         void search_matchesTitleAndDescription_returnsBoth() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle, projectWithDescription),
-                                    "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle, projectWithDescription));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "machine learning"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data.length()").value(2));
+                    .andExpect(jsonPath("$.data.projects").isArray())
+                    .andExpect(jsonPath("$.data.projects.length()").value(2));
         }
     }
 
@@ -216,24 +220,22 @@ class SearchControllerTest {
 
         @Test
         @WithMockUser
-        @DisplayName("1. Filter by status ACTIVE returns only active projects")
+        @DisplayName("1. Filter by status OPEN returns only active projects")
         void search_filterByActiveStatus_returnsOnlyActive() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
                                     .param("q", "project")
-                                    .param("status", "ACTIVE"))
+                                    .param("status", "OPEN"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].status").value("ACTIVE"));
+                    .andExpect(jsonPath("$.data.projects[0].status").value("OPEN"));
 
             ArgumentCaptor<SearchProjectsQuery> captor =
                     ArgumentCaptor.forClass(SearchProjectsQuery.class);
             verify(mediator).send(captor.capture());
-            assertThat(captor.getValue().status()).isEqualTo("ACTIVE");
+            assertThat(captor.getValue().status()).isEqualTo("OPEN");
         }
 
         @Test
@@ -241,17 +243,14 @@ class SearchControllerTest {
         @DisplayName("2. Filter by status COMPLETED returns only completed projects")
         void search_filterByCompletedStatus_returnsOnlyCompleted() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithDescription),
-                                    "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithDescription));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
                                     .param("q", "project")
                                     .param("status", "COMPLETED"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].status").value("COMPLETED"));
+                    .andExpect(jsonPath("$.data.projects[0].status").value("COMPLETED"));
 
             ArgumentCaptor<SearchProjectsQuery> captor =
                     ArgumentCaptor.forClass(SearchProjectsQuery.class);
@@ -264,9 +263,7 @@ class SearchControllerTest {
         @DisplayName("3. Filter by multiple tags passes tags to query")
         void search_filterByMultipleTags_passesTagsToQuery() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
@@ -285,21 +282,19 @@ class SearchControllerTest {
         @DisplayName("4. Filter by status and tags combined passes both to query")
         void search_filterByStatusAndTags_passesBoth() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
                                     .param("q", "project")
-                                    .param("status", "ACTIVE")
+                                    .param("status", "OPEN")
                                     .param("tags", "python"))
                     .andExpect(status().isOk());
 
             ArgumentCaptor<SearchProjectsQuery> captor =
                     ArgumentCaptor.forClass(SearchProjectsQuery.class);
             verify(mediator).send(captor.capture());
-            assertThat(captor.getValue().status()).isEqualTo("ACTIVE");
+            assertThat(captor.getValue().status()).isEqualTo("OPEN");
             assertThat(captor.getValue().tags()).contains("python");
         }
 
@@ -308,9 +303,7 @@ class SearchControllerTest {
         @DisplayName("5. Search without filters uses default values")
         void search_noFilters_usesDefaults() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "project"))
                     .andExpect(status().isOk());
@@ -336,9 +329,7 @@ class SearchControllerTest {
         @DisplayName("1. Custom page and size values are passed to query")
         void search_customPagination_passedToQuery() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
@@ -359,31 +350,25 @@ class SearchControllerTest {
         @DisplayName("2. First page with default size returns results")
         void search_firstPageDefaultSize_returnsResults() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle, projectWithDescription),
-                                    "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle, projectWithDescription));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "project").param("page", "0"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.length()").value(2));
+                    .andExpect(jsonPath("$.data.projects.length()").value(2));
         }
 
         @Test
         @WithMockUser
         @DisplayName("3. Page beyond results returns empty list")
         void search_pageBeyondResults_returnsEmpty() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
                                     .param("q", "project")
                                     .param("page", "999"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isEmpty());
+                    .andExpect(jsonPath("$.data.projects").isEmpty());
         }
 
         @Test
@@ -391,13 +376,11 @@ class SearchControllerTest {
         @DisplayName("4. Small page size returns limited results")
         void search_smallPageSize_returnsLimited() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "project").param("size", "1"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.length()").value(1));
+                    .andExpect(jsonPath("$.data.projects.length()").value(1));
         }
     }
 
@@ -412,18 +395,16 @@ class SearchControllerTest {
         @DisplayName("1. Search results contain expected fields")
         void search_results_containExpectedFields() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "machine"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].id").exists())
-                    .andExpect(jsonPath("$.data[0].title").exists())
-                    .andExpect(jsonPath("$.data[0].description").exists())
-                    .andExpect(jsonPath("$.data[0].status").exists())
-                    .andExpect(jsonPath("$.data[0].tags").exists())
-                    .andExpect(jsonPath("$.data[0].applicationsCount").exists());
+                    .andExpect(jsonPath("$.data.projects[0].id").exists())
+                    .andExpect(jsonPath("$.data.projects[0].title").exists())
+                    .andExpect(jsonPath("$.data.projects[0].description").exists())
+                    .andExpect(jsonPath("$.data.projects[0].status").exists())
+                    .andExpect(jsonPath("$.data.projects[0].requiredSkills").exists())
+                    .andExpect(jsonPath("$.data.projects[0].applicationCount").exists());
         }
 
         @Test
@@ -431,16 +412,14 @@ class SearchControllerTest {
         @DisplayName("2. Search results have correct tag values")
         void search_results_haveCorrectTags() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle), "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "machine"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].tags").isArray())
-                    .andExpect(jsonPath("$.data[0].tags[0]").value("python"))
-                    .andExpect(jsonPath("$.data[0].tags[1]").value("ml"))
-                    .andExpect(jsonPath("$.data[0].tags[2]").value("data"));
+                    .andExpect(jsonPath("$.data.projects[0].requiredSkills").isArray())
+                    .andExpect(jsonPath("$.data.projects[0].requiredSkills[0]").value("python"))
+                    .andExpect(jsonPath("$.data.projects[0].requiredSkills[1]").value("ml"))
+                    .andExpect(jsonPath("$.data.projects[0].requiredSkills[2]").value("data"));
         }
 
         @Test
@@ -448,15 +427,13 @@ class SearchControllerTest {
         @DisplayName("3. Title-match results ranked before description-match results")
         void search_titleMatchRankedHigher() throws Exception {
             when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    List.of(projectWithTitle, projectWithDescription),
-                                    "Projects retrieved successfully"));
+                    .thenReturn(searchResponse(projectWithTitle, projectWithDescription));
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "machine learning"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data[0].title").value("Machine Learning Pipeline"))
-                    .andExpect(jsonPath("$.data[1].title").value("Web Application"));
+                    .andExpect(
+                            jsonPath("$.data.projects[0].title").value("Machine Learning Pipeline"))
+                    .andExpect(jsonPath("$.data.projects[1].title").value("Web Application"));
         }
     }
 
@@ -470,26 +447,20 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("1. Search with no matching results returns empty list with 200")
         void search_noResults_returnsEmptyList() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "xyznonexistent"))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.code").value(0))
-                    .andExpect(jsonPath("$.data").isArray())
-                    .andExpect(jsonPath("$.data").isEmpty());
+                    .andExpect(jsonPath("$.data.projects").isArray())
+                    .andExpect(jsonPath("$.data.projects").isEmpty());
         }
 
         @Test
         @WithMockUser
         @DisplayName("2. Search with filters yielding no results returns empty list")
         void search_noResultsWithFilters_returnsEmptyList() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
@@ -497,7 +468,7 @@ class SearchControllerTest {
                                     .param("status", "DRAFT")
                                     .param("tags", "nonexistent-tag"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isEmpty());
+                    .andExpect(jsonPath("$.data.projects").isEmpty());
         }
     }
 
@@ -567,13 +538,13 @@ class SearchControllerTest {
         @DisplayName("1. Statistics returns all status counts")
         void statistics_returnsAllStatusCounts() throws Exception {
             Map<String, Long> stats =
-                    Map.of("ACTIVE", 15L, "COMPLETED", 8L, "DRAFT", 4L, "CANCELLED", 2L);
+                    Map.of("OPEN", 15L, "COMPLETED", 8L, "DRAFT", 4L, "CANCELLED", 2L);
             when(mediator.send(any(GetProjectStatisticsQuery.class)))
                     .thenReturn(ApiResponse.success(stats, "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.ACTIVE").value(15))
+                    .andExpect(jsonPath("$.data.OPEN").value(15))
                     .andExpect(jsonPath("$.data.COMPLETED").value(8))
                     .andExpect(jsonPath("$.data.DRAFT").value(4))
                     .andExpect(jsonPath("$.data.CANCELLED").value(2));
@@ -583,13 +554,13 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("2. Statistics with only one status returns single entry")
         void statistics_singleStatus_returnsSingleEntry() throws Exception {
-            Map<String, Long> stats = Map.of("ACTIVE", 5L);
+            Map<String, Long> stats = Map.of("OPEN", 5L);
             when(mediator.send(any(GetProjectStatisticsQuery.class)))
                     .thenReturn(ApiResponse.success(stats, "Statistics retrieved successfully"));
 
             mockMvc.perform(get("/api/v1/search/projects/statistics"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.ACTIVE").value(5))
+                    .andExpect(jsonPath("$.data.OPEN").value(5))
                     .andExpect(jsonPath("$.data.COMPLETED").doesNotExist());
         }
     }
@@ -604,38 +575,29 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("1. Search with special characters returns results")
         void search_specialCharacters_returnsResults() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "C++ programming"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isArray());
+                    .andExpect(jsonPath("$.data.projects").isArray());
         }
 
         @Test
         @WithMockUser
         @DisplayName("2. Search with unicode characters returns results")
         void search_unicodeCharacters_returnsResults() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "proje gelistirme"))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data").isArray());
+                    .andExpect(jsonPath("$.data.projects").isArray());
         }
 
         @Test
         @WithMockUser
         @DisplayName("3. Search with exactly minimum length query succeeds")
         void search_minLengthQuery_succeeds() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", "ab"))
                     .andExpect(status().isOk());
@@ -646,10 +608,7 @@ class SearchControllerTest {
         @DisplayName("4. Search with exactly maximum length query succeeds")
         void search_maxLengthQuery_succeeds() throws Exception {
             String maxQuery = "a".repeat(100);
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(get("/api/v1/search/projects").param("q", maxQuery))
                     .andExpect(status().isOk());
@@ -659,10 +618,7 @@ class SearchControllerTest {
         @WithMockUser
         @DisplayName("5. Search with maximum valid page size succeeds")
         void search_maxPageSize_succeeds() throws Exception {
-            when(mediator.send(any(SearchProjectsQuery.class)))
-                    .thenReturn(
-                            ApiResponse.success(
-                                    Collections.emptyList(), "Projects retrieved successfully"));
+            when(mediator.send(any(SearchProjectsQuery.class))).thenReturn(searchResponse());
 
             mockMvc.perform(
                             get("/api/v1/search/projects")
@@ -675,5 +631,30 @@ class SearchControllerTest {
             verify(mediator).send(captor.capture());
             assertThat(captor.getValue().size()).isEqualTo(100);
         }
+    }
+
+    private ApiResponse<PagedProjectsResult> searchResponse(ProjectDocument... documents) {
+        List<ProjectDetailDto> projects = List.of(documents).stream().map(this::toDto).toList();
+        return ApiResponse.success(
+                new PagedProjectsResult(projects, 0, projects.isEmpty() ? 0 : 1, projects.size()),
+                "Projects retrieved successfully");
+    }
+
+    private ProjectDetailDto toDto(ProjectDocument document) {
+        return new ProjectDetailDto(
+                document.getId(),
+                document.getOwnerId(),
+                document.getOwnerName(),
+                document.getOwnerEmail(),
+                document.getTitle(),
+                document.getDescription(),
+                document.getSummary(),
+                document.getApplicationCount(),
+                document.getStatus() != null ? ProjectStatus.valueOf(document.getStatus()) : null,
+                document.getMaxTeamSize(),
+                document.getRequiredSkills() != null ? document.getRequiredSkills() : List.of(),
+                document.getCategory(),
+                document.getDeadline(),
+                document.getCreatedAt());
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/SearchControllerTest.java
@@ -650,7 +650,7 @@ class SearchControllerTest {
                 document.getDescription(),
                 document.getSummary(),
                 document.getApplicationCount(),
-                document.getStatus() != null ? ProjectStatus.valueOf(document.getStatus()) : null,
+                ProjectStatus.fromString(document.getStatus()),
                 document.getMaxTeamSize(),
                 document.getRequiredSkills() != null ? document.getRequiredSkills() : List.of(),
                 document.getCategory(),


### PR DESCRIPTION
 ## Summary

  - Align GET /api/v1/search/projects response with the regular project list response shape.
  - Return PagedProjectsResult from search instead of a raw List<ProjectDocument>.
  - Map Elasticsearch search hits into ProjectDetailDto items under data.projects.
  - Flatten project owner fields in ProjectDocument:
      - ownerId
      - ownerName
      - ownerEmail

  - Rename search document application count from applicationsCount to applicationCount.
  - Include project fields needed by frontend cards/details:
      - maxTeamSize
      - requiredSkills
      - deadline

  - Update ProjectDocumentMapper to populate the new flat fields from ProjectEntity.
  - Update search controller tests for the new paginated response shape.

  ## Testing

  - ./gradlew compileJava
  - ./gradlew test --tests com.iyte_yazilim.proje_pazari.presentation.controllers.SearchControllerTest
  - ./gradlew --no-configuration-cache spotlessCheck

---

closes #133 