### PR TITLE
Feat/projects not indexed

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryService.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryService.java
@@ -1,14 +1,15 @@
 package com.iyte_yazilim.proje_pazari.application.services;
 
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -19,33 +20,62 @@ import org.springframework.transaction.annotation.Transactional;
         matchIfMissing = true)
 public class PendingIndexRetryService {
 
+    /** Max transient retries before an entry is marked permanently {@code FAILED}. */
+    static final int MAX_ATTEMPTS = 10;
+
     private final PendingIndexRepository pendingIndexRepository;
     private final ElasticsearchSyncService syncService;
 
     @Scheduled(fixedDelay = 60_000)
-    @Transactional
     public void retryPendingIndexes() {
-        List<PendingIndexEntity> pending = pendingIndexRepository.findByStatus("PENDING");
+        List<PendingIndexEntity> pending =
+                pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING);
         if (pending.isEmpty()) {
             return;
         }
 
         log.info("Retrying {} pending project index entries.", pending.size());
 
+        // No method-level transaction: each save() below commits on its own, so a DB connection is
+        // not pinned across the (potentially slow) Elasticsearch calls while ES is unavailable.
         for (PendingIndexEntity entry : pending) {
             try {
                 syncService.indexProject(entry.getProjectId());
-                entry.setStatus("DONE");
+                entry.setStatus(PendingIndexStatus.DONE);
                 log.info(
                         "Successfully reindexed previously failed project: {}",
                         entry.getProjectId());
+            } catch (ProjectNotFoundException e) {
+                // The project no longer exists (created during an outage, then deleted). This will
+                // never succeed, so mark it terminal and best-effort drop any stale ES document.
+                entry.setStatus(PendingIndexStatus.FAILED);
+                log.warn(
+                        "Project {} no longer exists; marking index retry entry FAILED.",
+                        entry.getProjectId());
+                try {
+                    syncService.deleteProjectIndex(entry.getProjectId());
+                } catch (Exception cleanupEx) {
+                    log.warn(
+                            "Failed to remove stale index document for missing project {}: {}",
+                            entry.getProjectId(),
+                            cleanupEx.getMessage());
+                }
             } catch (Exception e) {
                 entry.setAttemptCount(entry.getAttemptCount() + 1);
-                log.warn(
-                        "Retry #{} for project {} still failing: {}",
-                        entry.getAttemptCount(),
-                        entry.getProjectId(),
-                        e.getMessage());
+                if (entry.getAttemptCount() >= MAX_ATTEMPTS) {
+                    entry.setStatus(PendingIndexStatus.FAILED);
+                    log.error(
+                            "Project {} index retry permanently FAILED after {} attempts: {}",
+                            entry.getProjectId(),
+                            entry.getAttemptCount(),
+                            e.getMessage());
+                } else {
+                    log.warn(
+                            "Retry #{} for project {} still failing: {}",
+                            entry.getAttemptCount(),
+                            entry.getProjectId(),
+                            e.getMessage());
+                }
             }
             pendingIndexRepository.save(entry);
         }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryService.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryService.java
@@ -1,0 +1,53 @@
+package com.iyte_yazilim.proje_pazari.application.services;
+
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@ConditionalOnProperty(
+        name = "spring.data.elasticsearch.enabled",
+        havingValue = "true",
+        matchIfMissing = true)
+public class PendingIndexRetryService {
+
+    private final PendingIndexRepository pendingIndexRepository;
+    private final ElasticsearchSyncService syncService;
+
+    @Scheduled(fixedDelay = 60_000)
+    @Transactional
+    public void retryPendingIndexes() {
+        List<PendingIndexEntity> pending = pendingIndexRepository.findByStatus("PENDING");
+        if (pending.isEmpty()) {
+            return;
+        }
+
+        log.info("Retrying {} pending project index entries.", pending.size());
+
+        for (PendingIndexEntity entry : pending) {
+            try {
+                syncService.indexProject(entry.getProjectId());
+                entry.setStatus("DONE");
+                log.info(
+                        "Successfully reindexed previously failed project: {}",
+                        entry.getProjectId());
+            } catch (Exception e) {
+                entry.setAttemptCount(entry.getAttemptCount() + 1);
+                log.warn(
+                        "Retry #{} for project {} still failing: {}",
+                        entry.getAttemptCount(),
+                        entry.getProjectId(),
+                        e.getMessage());
+            }
+            pendingIndexRepository.save(entry);
+        }
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/PendingIndexRepository.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/PendingIndexRepository.java
@@ -1,10 +1,13 @@
 package com.iyte_yazilim.proje_pazari.infrastructure.persistence;
 
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexStatus;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PendingIndexRepository extends JpaRepository<PendingIndexEntity, String> {
 
-    List<PendingIndexEntity> findByStatus(String status);
+    List<PendingIndexEntity> findByStatus(PendingIndexStatus status);
+
+    boolean existsByProjectIdAndStatus(String projectId, PendingIndexStatus status);
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/PendingIndexRepository.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/PendingIndexRepository.java
@@ -1,0 +1,10 @@
+package com.iyte_yazilim.proje_pazari.infrastructure.persistence;
+
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PendingIndexRepository extends JpaRepository<PendingIndexEntity, String> {
+
+    List<PendingIndexEntity> findByStatus(String status);
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListener.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListener.java
@@ -8,6 +8,8 @@ import com.iyte_yazilim.proje_pazari.domain.events.UserDeletedEvent;
 import com.iyte_yazilim.proje_pazari.domain.events.UserRegisteredEvent;
 import com.iyte_yazilim.proje_pazari.domain.events.UserUpdatedEvent;
 import com.iyte_yazilim.proje_pazari.infrastructure.metrics.BusinessMetricsService;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -27,6 +29,7 @@ public class ElasticsearchEventListener {
 
     private final ElasticsearchSyncService syncService;
     private final BusinessMetricsService metricsService;
+    private final PendingIndexRepository pendingIndexRepository;
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Async
@@ -42,6 +45,7 @@ public class ElasticsearchEventListener {
                     event.projectId(),
                     e.getMessage(),
                     e);
+            pendingIndexRepository.save(PendingIndexEntity.of(event.projectId()));
         }
     }
 
@@ -59,6 +63,7 @@ public class ElasticsearchEventListener {
                     event.projectId(),
                     e.getMessage(),
                     e);
+            pendingIndexRepository.save(PendingIndexEntity.of(event.projectId()));
         }
     }
 

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListener.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListener.java
@@ -10,6 +10,7 @@ import com.iyte_yazilim.proje_pazari.domain.events.UserUpdatedEvent;
 import com.iyte_yazilim.proje_pazari.infrastructure.metrics.BusinessMetricsService;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -45,7 +46,7 @@ public class ElasticsearchEventListener {
                     event.projectId(),
                     e.getMessage(),
                     e);
-            pendingIndexRepository.save(PendingIndexEntity.of(event.projectId()));
+            enqueuePendingIndex(event.projectId());
         }
     }
 
@@ -63,8 +64,21 @@ public class ElasticsearchEventListener {
                     event.projectId(),
                     e.getMessage(),
                     e);
-            pendingIndexRepository.save(PendingIndexEntity.of(event.projectId()));
+            enqueuePendingIndex(event.projectId());
         }
+    }
+
+    /**
+     * Queues a project for retry indexing, skipping the insert when a {@code PENDING} entry for the
+     * same project already exists. Avoids accumulating duplicate rows when a project fails to index
+     * repeatedly during an outage.
+     */
+    private void enqueuePendingIndex(String projectId) {
+        if (pendingIndexRepository.existsByProjectIdAndStatus(
+                projectId, PendingIndexStatus.PENDING)) {
+            return;
+        }
+        pendingIndexRepository.save(PendingIndexEntity.of(projectId));
     }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/PendingIndexEntity.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/PendingIndexEntity.java
@@ -1,0 +1,54 @@
+package com.iyte_yazilim.proje_pazari.infrastructure.persistence.models;
+
+import com.github.f4b6a3.ulid.Ulid;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "pending_index")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PendingIndexEntity {
+
+    @Id
+    @Column(length = 26)
+    private String id;
+
+    @Column(name = "project_id", nullable = false, length = 26)
+    private String projectId;
+
+    @Column(name = "attempt_count", nullable = false)
+    @Builder.Default
+    private int attemptCount = 0;
+
+    @Column(nullable = false, length = 20)
+    @Builder.Default
+    private String status = "PENDING";
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        if (id == null || id.isBlank()) {
+            id = Ulid.fast().toString();
+        }
+        createdAt = LocalDateTime.now();
+    }
+
+    public static PendingIndexEntity of(String projectId) {
+        return PendingIndexEntity.builder().projectId(projectId).build();
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/PendingIndexEntity.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/PendingIndexEntity.java
@@ -3,6 +3,8 @@ package com.iyte_yazilim.proje_pazari.infrastructure.persistence.models;
 import com.github.f4b6a3.ulid.Ulid;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.PrePersist;
 import jakarta.persistence.Table;
@@ -33,9 +35,10 @@ public class PendingIndexEntity {
     @Builder.Default
     private int attemptCount = 0;
 
+    @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
     @Builder.Default
-    private String status = "PENDING";
+    private PendingIndexStatus status = PendingIndexStatus.PENDING;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/PendingIndexStatus.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/models/PendingIndexStatus.java
@@ -1,0 +1,11 @@
+package com.iyte_yazilim.proje_pazari.infrastructure.persistence.models;
+
+/** Lifecycle state of a {@link PendingIndexEntity} retry entry. */
+public enum PendingIndexStatus {
+    /** Awaiting (re)indexing; picked up by the scheduled retry loop. */
+    PENDING,
+    /** Successfully indexed; terminal. */
+    DONE,
+    /** Permanently failed (project gone or max attempts exceeded); terminal, no longer retried. */
+    FAILED
+}

--- a/src/main/resources/db/migration/V4__add_pending_index_table.sql
+++ b/src/main/resources/db/migration/V4__add_pending_index_table.sql
@@ -5,3 +5,12 @@ CREATE TABLE pending_index (
     status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
     created_at TIMESTAMP NOT NULL
 );
+
+-- At most one live (PENDING) retry entry per project, preventing duplicate rows
+-- when a project repeatedly fails to index during an outage.
+CREATE UNIQUE INDEX ux_pending_index_project_pending
+    ON pending_index (project_id)
+    WHERE status = 'PENDING';
+
+-- Supports the scheduled retry loop's lookup by status.
+CREATE INDEX ix_pending_index_status ON pending_index (status);

--- a/src/main/resources/db/migration/V4__add_pending_index_table.sql
+++ b/src/main/resources/db/migration/V4__add_pending_index_table.sql
@@ -1,0 +1,7 @@
+CREATE TABLE pending_index (
+    id VARCHAR(26) PRIMARY KEY,
+    project_id VARCHAR(26) NOT NULL,
+    attempt_count INT NOT NULL DEFAULT 0,
+    status VARCHAR(20) NOT NULL DEFAULT 'PENDING',
+    created_at TIMESTAMP NOT NULL
+);

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryServiceTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryServiceTest.java
@@ -1,0 +1,119 @@
+package com.iyte_yazilim.proje_pazari.application.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PendingIndexRetryServiceTest {
+
+    @Mock private PendingIndexRepository pendingIndexRepository;
+    @Mock private ElasticsearchSyncService syncService;
+
+    @InjectMocks private PendingIndexRetryService retryService;
+
+    private PendingIndexEntity pendingEntry(String projectId) {
+        PendingIndexEntity entry = new PendingIndexEntity();
+        entry.setProjectId(projectId);
+        entry.setStatus("PENDING");
+        entry.setAttemptCount(0);
+        return entry;
+    }
+
+    @Test
+    @DisplayName("Should do nothing when there are no pending entries")
+    void retryPendingIndexes_noPendingEntries_doesNothing() {
+        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of());
+
+        retryService.retryPendingIndexes();
+
+        verifyNoInteractions(syncService);
+        verify(pendingIndexRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("Should set status to DONE and save after successful retry")
+    void retryPendingIndexes_successfulRetry_setsStatusDoneAndSaves() {
+        PendingIndexEntity entry = pendingEntry("proj-1");
+        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(entry));
+
+        retryService.retryPendingIndexes();
+
+        verify(syncService).indexProject("proj-1");
+        assertEquals("DONE", entry.getStatus());
+        verify(pendingIndexRepository).save(entry);
+    }
+
+    @Test
+    @DisplayName("Should increment attemptCount and save when retry still fails")
+    void retryPendingIndexes_retryFails_incrementsAttemptCountAndSaves() {
+        PendingIndexEntity entry = pendingEntry("proj-2");
+        doThrow(new RuntimeException("ES still down")).when(syncService).indexProject("proj-2");
+        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(entry));
+
+        retryService.retryPendingIndexes();
+
+        assertEquals("PENDING", entry.getStatus());
+        assertEquals(1, entry.getAttemptCount());
+        verify(pendingIndexRepository).save(entry);
+    }
+
+    @Test
+    @DisplayName("Should not throw when a retry fails — loop continues for remaining entries")
+    void retryPendingIndexes_oneEntryFails_continuesWithRemaining() {
+        PendingIndexEntity failing = pendingEntry("proj-fail");
+        PendingIndexEntity succeeding = pendingEntry("proj-ok");
+        doThrow(new RuntimeException("ES down")).when(syncService).indexProject("proj-fail");
+        when(pendingIndexRepository.findByStatus("PENDING"))
+                .thenReturn(List.of(failing, succeeding));
+
+        assertDoesNotThrow(() -> retryService.retryPendingIndexes());
+
+        verify(syncService).indexProject("proj-fail");
+        verify(syncService).indexProject("proj-ok");
+        assertEquals("PENDING", failing.getStatus());
+        assertEquals("DONE", succeeding.getStatus());
+        verify(pendingIndexRepository).save(failing);
+        verify(pendingIndexRepository).save(succeeding);
+    }
+
+    @Test
+    @DisplayName("Should process all pending entries independently")
+    void retryPendingIndexes_multipleEntries_allProcessed() {
+        PendingIndexEntity e1 = pendingEntry("proj-1");
+        PendingIndexEntity e2 = pendingEntry("proj-2");
+        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(e1, e2));
+
+        retryService.retryPendingIndexes();
+
+        verify(syncService).indexProject("proj-1");
+        verify(syncService).indexProject("proj-2");
+        assertEquals("DONE", e1.getStatus());
+        assertEquals("DONE", e2.getStatus());
+        verify(pendingIndexRepository).save(e1);
+        verify(pendingIndexRepository).save(e2);
+    }
+
+    @Test
+    @DisplayName("Should accumulate attemptCount across multiple failed retries")
+    void retryPendingIndexes_repeatedFailures_accumulatesAttemptCount() {
+        PendingIndexEntity entry = pendingEntry("proj-3");
+        entry.setAttemptCount(2);
+        doThrow(new RuntimeException("ES down")).when(syncService).indexProject("proj-3");
+        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(entry));
+
+        retryService.retryPendingIndexes();
+
+        assertEquals(3, entry.getAttemptCount());
+        assertEquals("PENDING", entry.getStatus());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryServiceTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/services/PendingIndexRetryServiceTest.java
@@ -3,8 +3,10 @@ package com.iyte_yazilim.proje_pazari.application.services;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import com.iyte_yazilim.proje_pazari.domain.exceptions.ProjectNotFoundException;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexStatus;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,7 +26,7 @@ class PendingIndexRetryServiceTest {
     private PendingIndexEntity pendingEntry(String projectId) {
         PendingIndexEntity entry = new PendingIndexEntity();
         entry.setProjectId(projectId);
-        entry.setStatus("PENDING");
+        entry.setStatus(PendingIndexStatus.PENDING);
         entry.setAttemptCount(0);
         return entry;
     }
@@ -32,7 +34,7 @@ class PendingIndexRetryServiceTest {
     @Test
     @DisplayName("Should do nothing when there are no pending entries")
     void retryPendingIndexes_noPendingEntries_doesNothing() {
-        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of());
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING)).thenReturn(List.of());
 
         retryService.retryPendingIndexes();
 
@@ -44,12 +46,13 @@ class PendingIndexRetryServiceTest {
     @DisplayName("Should set status to DONE and save after successful retry")
     void retryPendingIndexes_successfulRetry_setsStatusDoneAndSaves() {
         PendingIndexEntity entry = pendingEntry("proj-1");
-        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(entry));
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING))
+                .thenReturn(List.of(entry));
 
         retryService.retryPendingIndexes();
 
         verify(syncService).indexProject("proj-1");
-        assertEquals("DONE", entry.getStatus());
+        assertEquals(PendingIndexStatus.DONE, entry.getStatus());
         verify(pendingIndexRepository).save(entry);
     }
 
@@ -58,12 +61,47 @@ class PendingIndexRetryServiceTest {
     void retryPendingIndexes_retryFails_incrementsAttemptCountAndSaves() {
         PendingIndexEntity entry = pendingEntry("proj-2");
         doThrow(new RuntimeException("ES still down")).when(syncService).indexProject("proj-2");
-        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(entry));
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING))
+                .thenReturn(List.of(entry));
 
         retryService.retryPendingIndexes();
 
-        assertEquals("PENDING", entry.getStatus());
+        assertEquals(PendingIndexStatus.PENDING, entry.getStatus());
         assertEquals(1, entry.getAttemptCount());
+        verify(pendingIndexRepository).save(entry);
+    }
+
+    @Test
+    @DisplayName("Should mark FAILED and drop stale index doc when project no longer exists")
+    void retryPendingIndexes_projectMissing_marksFailedAndDeletesIndex() {
+        PendingIndexEntity entry = pendingEntry("proj-gone");
+        doThrow(new ProjectNotFoundException("proj-gone"))
+                .when(syncService)
+                .indexProject("proj-gone");
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING))
+                .thenReturn(List.of(entry));
+
+        retryService.retryPendingIndexes();
+
+        assertEquals(PendingIndexStatus.FAILED, entry.getStatus());
+        assertEquals(0, entry.getAttemptCount());
+        verify(syncService).deleteProjectIndex("proj-gone");
+        verify(pendingIndexRepository).save(entry);
+    }
+
+    @Test
+    @DisplayName("Should mark FAILED once attemptCount reaches the max attempt cap")
+    void retryPendingIndexes_maxAttemptsReached_marksFailed() {
+        PendingIndexEntity entry = pendingEntry("proj-poison");
+        entry.setAttemptCount(PendingIndexRetryService.MAX_ATTEMPTS - 1);
+        doThrow(new RuntimeException("ES down")).when(syncService).indexProject("proj-poison");
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING))
+                .thenReturn(List.of(entry));
+
+        retryService.retryPendingIndexes();
+
+        assertEquals(PendingIndexRetryService.MAX_ATTEMPTS, entry.getAttemptCount());
+        assertEquals(PendingIndexStatus.FAILED, entry.getStatus());
         verify(pendingIndexRepository).save(entry);
     }
 
@@ -73,15 +111,15 @@ class PendingIndexRetryServiceTest {
         PendingIndexEntity failing = pendingEntry("proj-fail");
         PendingIndexEntity succeeding = pendingEntry("proj-ok");
         doThrow(new RuntimeException("ES down")).when(syncService).indexProject("proj-fail");
-        when(pendingIndexRepository.findByStatus("PENDING"))
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING))
                 .thenReturn(List.of(failing, succeeding));
 
         assertDoesNotThrow(() -> retryService.retryPendingIndexes());
 
         verify(syncService).indexProject("proj-fail");
         verify(syncService).indexProject("proj-ok");
-        assertEquals("PENDING", failing.getStatus());
-        assertEquals("DONE", succeeding.getStatus());
+        assertEquals(PendingIndexStatus.PENDING, failing.getStatus());
+        assertEquals(PendingIndexStatus.DONE, succeeding.getStatus());
         verify(pendingIndexRepository).save(failing);
         verify(pendingIndexRepository).save(succeeding);
     }
@@ -91,14 +129,15 @@ class PendingIndexRetryServiceTest {
     void retryPendingIndexes_multipleEntries_allProcessed() {
         PendingIndexEntity e1 = pendingEntry("proj-1");
         PendingIndexEntity e2 = pendingEntry("proj-2");
-        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(e1, e2));
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING))
+                .thenReturn(List.of(e1, e2));
 
         retryService.retryPendingIndexes();
 
         verify(syncService).indexProject("proj-1");
         verify(syncService).indexProject("proj-2");
-        assertEquals("DONE", e1.getStatus());
-        assertEquals("DONE", e2.getStatus());
+        assertEquals(PendingIndexStatus.DONE, e1.getStatus());
+        assertEquals(PendingIndexStatus.DONE, e2.getStatus());
         verify(pendingIndexRepository).save(e1);
         verify(pendingIndexRepository).save(e2);
     }
@@ -109,11 +148,12 @@ class PendingIndexRetryServiceTest {
         PendingIndexEntity entry = pendingEntry("proj-3");
         entry.setAttemptCount(2);
         doThrow(new RuntimeException("ES down")).when(syncService).indexProject("proj-3");
-        when(pendingIndexRepository.findByStatus("PENDING")).thenReturn(List.of(entry));
+        when(pendingIndexRepository.findByStatus(PendingIndexStatus.PENDING))
+                .thenReturn(List.of(entry));
 
         retryService.retryPendingIndexes();
 
         assertEquals(3, entry.getAttemptCount());
-        assertEquals("PENDING", entry.getStatus());
+        assertEquals(PendingIndexStatus.PENDING, entry.getStatus());
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListenerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListenerTest.java
@@ -8,7 +8,6 @@ import com.iyte_yazilim.proje_pazari.domain.events.ProjectDeletedEvent;
 import com.iyte_yazilim.proje_pazari.domain.events.ProjectUpdatedEvent;
 import com.iyte_yazilim.proje_pazari.infrastructure.metrics.BusinessMetricsService;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -55,7 +54,8 @@ class ElasticsearchEventListenerTest {
     }
 
     @Test
-    @DisplayName("Should increment index failure and queue for retry when project created sync throws")
+    @DisplayName(
+            "Should increment index failure and queue for retry when project created sync throws")
     void shouldIncrementIndexFailure_whenProjectCreatedSyncThrows() throws Exception {
         // Given
         ProjectCreatedEvent event =
@@ -104,7 +104,8 @@ class ElasticsearchEventListenerTest {
     }
 
     @Test
-    @DisplayName("Should increment index failure and queue for retry when project updated sync throws")
+    @DisplayName(
+            "Should increment index failure and queue for retry when project updated sync throws")
     void shouldIncrementIndexFailure_whenProjectUpdatedSyncThrows() throws Exception {
         // Given
         ProjectUpdatedEvent event =

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListenerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListenerTest.java
@@ -8,6 +8,7 @@ import com.iyte_yazilim.proje_pazari.domain.events.ProjectDeletedEvent;
 import com.iyte_yazilim.proje_pazari.domain.events.ProjectUpdatedEvent;
 import com.iyte_yazilim.proje_pazari.infrastructure.metrics.BusinessMetricsService;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -67,6 +68,9 @@ class ElasticsearchEventListenerTest {
                         "Owner",
                         LocalDateTime.now());
         doThrow(new RuntimeException("ES unavailable")).when(syncService).indexProject("proj-1");
+        when(pendingIndexRepository.existsByProjectIdAndStatus(
+                        "proj-1", PendingIndexStatus.PENDING))
+                .thenReturn(false);
 
         // When
         listener.handleProjectCreated(event);
@@ -75,6 +79,30 @@ class ElasticsearchEventListenerTest {
         verify(metricsService).incrementEsIndexFailure();
         verify(metricsService, never()).incrementEsIndexSuccess();
         verify(pendingIndexRepository).save(argThat(e -> "proj-1".equals(e.getProjectId())));
+    }
+
+    @Test
+    @DisplayName("Should not queue a duplicate when a PENDING entry already exists")
+    void shouldNotQueueDuplicate_whenPendingEntryAlreadyExists() throws Exception {
+        // Given
+        ProjectCreatedEvent event =
+                new ProjectCreatedEvent(
+                        "proj-1",
+                        "Title",
+                        "owner-1",
+                        "owner@test.com",
+                        "Owner",
+                        LocalDateTime.now());
+        doThrow(new RuntimeException("ES unavailable")).when(syncService).indexProject("proj-1");
+        when(pendingIndexRepository.existsByProjectIdAndStatus(
+                        "proj-1", PendingIndexStatus.PENDING))
+                .thenReturn(true);
+
+        // When
+        listener.handleProjectCreated(event);
+
+        // Then
+        verify(pendingIndexRepository, never()).save(any());
     }
 
     // ── handleProjectUpdated ──────────────────────────────────────────────
@@ -118,6 +146,9 @@ class ElasticsearchEventListenerTest {
                         List.of(),
                         LocalDateTime.now());
         doThrow(new RuntimeException("ES unavailable")).when(syncService).indexProject("proj-2");
+        when(pendingIndexRepository.existsByProjectIdAndStatus(
+                        "proj-2", PendingIndexStatus.PENDING))
+                .thenReturn(false);
 
         // When
         listener.handleProjectUpdated(event);

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListenerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/elasticsearch/ElasticsearchEventListenerTest.java
@@ -7,6 +7,8 @@ import com.iyte_yazilim.proje_pazari.domain.events.ProjectCreatedEvent;
 import com.iyte_yazilim.proje_pazari.domain.events.ProjectDeletedEvent;
 import com.iyte_yazilim.proje_pazari.domain.events.ProjectUpdatedEvent;
 import com.iyte_yazilim.proje_pazari.infrastructure.metrics.BusinessMetricsService;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.PendingIndexRepository;
+import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.PendingIndexEntity;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -22,6 +24,8 @@ class ElasticsearchEventListenerTest {
     @Mock private ElasticsearchSyncService syncService;
 
     @Mock private BusinessMetricsService metricsService;
+
+    @Mock private PendingIndexRepository pendingIndexRepository;
 
     @InjectMocks private ElasticsearchEventListener listener;
 
@@ -47,10 +51,11 @@ class ElasticsearchEventListenerTest {
         verify(syncService).indexProject("proj-1");
         verify(metricsService).incrementEsIndexSuccess();
         verify(metricsService, never()).incrementEsIndexFailure();
+        verifyNoInteractions(pendingIndexRepository);
     }
 
     @Test
-    @DisplayName("Should increment index failure when project created sync throws")
+    @DisplayName("Should increment index failure and queue for retry when project created sync throws")
     void shouldIncrementIndexFailure_whenProjectCreatedSyncThrows() throws Exception {
         // Given
         ProjectCreatedEvent event =
@@ -69,6 +74,7 @@ class ElasticsearchEventListenerTest {
         // Then
         verify(metricsService).incrementEsIndexFailure();
         verify(metricsService, never()).incrementEsIndexSuccess();
+        verify(pendingIndexRepository).save(argThat(e -> "proj-1".equals(e.getProjectId())));
     }
 
     // ── handleProjectUpdated ──────────────────────────────────────────────
@@ -94,10 +100,11 @@ class ElasticsearchEventListenerTest {
         verify(syncService).indexProject("proj-2");
         verify(metricsService).incrementEsIndexSuccess();
         verify(metricsService, never()).incrementEsIndexFailure();
+        verifyNoInteractions(pendingIndexRepository);
     }
 
     @Test
-    @DisplayName("Should increment index failure when project updated sync throws")
+    @DisplayName("Should increment index failure and queue for retry when project updated sync throws")
     void shouldIncrementIndexFailure_whenProjectUpdatedSyncThrows() throws Exception {
         // Given
         ProjectUpdatedEvent event =
@@ -117,6 +124,7 @@ class ElasticsearchEventListenerTest {
         // Then
         verify(metricsService).incrementEsIndexFailure();
         verify(metricsService, never()).incrementEsIndexSuccess();
+        verify(pendingIndexRepository).save(argThat(e -> "proj-2".equals(e.getProjectId())));
     }
 
     // ── handleProjectDeleted ──────────────────────────────────────────────


### PR DESCRIPTION
  Summary

  - Adds a DB-backed retry queue to fix the permanent search gap that occurs when a project is created or updated while Elasticsearch is unavailable
  - On indexing failure, the project ID is persisted to a new pending_index table; a scheduled task retries all pending entries every 60 seconds and marks them DONE on success
  - The existing admin reindex endpoint remains untouched

  What changed

  New files
  - V4__add_pending_index_table.sql — Flyway migration adding the pending_index table (project_id, status, attempt_count, created_at)
  - PendingIndexEntity / PendingIndexRepository — JPA entity and Spring Data repository for the queue
  - PendingIndexRetryService — @Scheduled(fixedDelay = 60s) service that reads PENDING entries, retries ElasticsearchSyncService.indexProject(), and updates status accordingly

  Modified files
  - ElasticsearchEventListener — catch blocks for handleProjectCreated and handleProjectUpdated now call pendingIndexRepository.save(PendingIndexEntity.of(projectId)) after logging the failure

  Test plan

  - [ ] PendingIndexRetryServiceTest — 6 unit tests: no-op on empty queue, success sets status DONE, failure increments attemptCount, loop resilience when one entry fails, multiple entries processed
  independently, attemptCount accumulation across retries
  - [ ] ElasticsearchEventListenerTest — existing failure tests updated to assert pendingIndexRepository.save() is called with the correct project ID; existing success tests updated to assert
  pendingIndexRepository is never touched

  Manual verification
  1. Start the app with Elasticsearch stopped
  2. Create a project — expect HTTP 201 and a PENDING row in pending_index
  3. Start Elasticsearch
  4. Wait ≤ 60 s — row should transition to DONE
  5. GET /api/v1/search/projects?q=<title> should return the project

  Closes #138
