### PR TITLE
fix(user): map preferredLanguage in profile update (#127, #139)

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandler.java
@@ -5,10 +5,10 @@ import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.application.mappers.UserDtoMapper;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.entities.User;
 import com.iyte_yazilim.proje_pazari.domain.events.UserUpdatedEvent;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IUserRepository;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class UpdateUserProfileHandler
         implements IRequestHandler<UpdateUserProfileCommand, ApiResponse<UserDto>> {
 
-    private final UserRepository userRepository;
+    private final IUserRepository userRepository;
     private final UserDtoMapper userDtoMapper;
     private final MessageService messageService;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -34,7 +34,7 @@ public class UpdateUserProfileHandler
             isolation = Isolation.READ_COMMITTED,
             propagation = Propagation.REQUIRED)
     public ApiResponse<UserDto> handle(UpdateUserProfileCommand command) {
-        UserEntity user =
+        User user =
                 userRepository
                         .findById(command.userId())
                         .orElseThrow(() -> new UserNotFoundException(command.userId()));
@@ -55,9 +55,12 @@ public class UpdateUserProfileHandler
         if (command.githubUrl() != null) {
             user.setGithubUrl(command.githubUrl().isBlank() ? null : command.githubUrl());
         }
+        if (command.preferredLanguage() != null) {
+            user.setPreferredLanguage(command.preferredLanguage());
+        }
 
-        UserEntity savedUser = userRepository.save(user);
-        UserDto userDto = userDtoMapper.toDto(savedUser);
+        User savedUser = userRepository.save(user);
+        UserDto userDto = userDtoMapper.domainToDto(savedUser);
 
         applicationEventPublisher.publishEvent(
                 new UserUpdatedEvent(

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileValidator.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileValidator.java
@@ -3,10 +3,13 @@ package com.iyte_yazilim.proje_pazari.application.commands.updateUserProfile;
 import com.iyte_yazilim.proje_pazari.domain.validators.IValidator;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import org.springframework.stereotype.Component;
 
 @Component
 public class UpdateUserProfileValidator implements IValidator<UpdateUserProfileCommand> {
+
+    private static final Set<String> SUPPORTED_LANGUAGES = Set.of("tr", "en");
 
     @Override
     public String[] validate(UpdateUserProfileCommand command) {
@@ -22,6 +25,10 @@ public class UpdateUserProfileValidator implements IValidator<UpdateUserProfileC
                 && !command.githubUrl().isBlank()
                 && !command.githubUrl().matches("^https://github\\.com/[a-zA-Z0-9_-]+(/.*)?$")) {
             errors.add("Invalid GitHub URL format");
+        }
+        if (command.preferredLanguage() != null
+                && !SUPPORTED_LANGUAGES.contains(command.preferredLanguage())) {
+            errors.add("Invalid preferred language. Supported languages: " + SUPPORTED_LANGUAGES);
         }
 
         return errors.toArray(new String[0]);

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/dtos/UserProfileDTO.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/dtos/UserProfileDTO.java
@@ -15,6 +15,8 @@ public record UserProfileDTO(
         @Schema(description = "Profile picture URL") String profilePictureUrl,
         @Schema(description = "LinkedIn profile URL") String linkedinUrl,
         @Schema(description = "GitHub profile URL") String githubUrl,
+        @Schema(description = "Preferred language (tr, en)", example = "en")
+                String preferredLanguage,
         @Schema(description = "Account creation timestamp") LocalDateTime joinedAt,
         @Schema(description = "Number of projects created by user") int projectsCreated,
         @Schema(description = "Number of applications submitted by user") int applicationsSubmitted,

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/mappers/UserDtoMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/mappers/UserDtoMapper.java
@@ -13,7 +13,6 @@ public interface UserDtoMapper {
     @Mapping(
             target = "userId",
             expression = "java(user.getId() != null ? user.getId().toString() : null)")
-    @Mapping(target = "preferredLanguage", ignore = true)
     UserDto domainToDto(User user);
 
     // Map UserEntity -> DTO

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/mappers/UserDtoMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/mappers/UserDtoMapper.java
@@ -2,7 +2,6 @@ package com.iyte_yazilim.proje_pazari.application.mappers;
 
 import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.domain.entities.User;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 
@@ -14,8 +13,4 @@ public interface UserDtoMapper {
             target = "userId",
             expression = "java(user.getId() != null ? user.getId().toString() : null)")
     UserDto domainToDto(User user);
-
-    // Map UserEntity -> DTO
-    @Mapping(target = "userId", source = "id")
-    UserDto toDto(UserEntity userEntity);
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandler.java
@@ -68,6 +68,7 @@ public class GetUserProfileHandler
                         user.getProfilePictureUrl(),
                         user.getLinkedinUrl(),
                         user.getGithubUrl(),
+                        user.getPreferredLanguage(),
                         user.getCreatedAt(),
                         projectsCreated,
                         applicationsSubmitted,

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/entities/User.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/entities/User.java
@@ -72,6 +72,9 @@ public class User extends BaseEntity<Ulid> {
     /** User's GitHub profile URL. Optional social link. */
     private String githubUrl;
 
+    /** User's preferred language for UI/messages (e.g. "tr", "en"). */
+    private String preferredLanguage;
+
     /** Indicates whether the user account is active. Inactive accounts cannot log in. */
     private boolean isActive;
 
@@ -250,6 +253,10 @@ public class User extends BaseEntity<Ulid> {
 
     public void setGithubUrl(String githubUrl) {
         this.githubUrl = githubUrl;
+    }
+
+    public void setPreferredLanguage(String preferredLanguage) {
+        this.preferredLanguage = preferredLanguage;
     }
 
     // ---------------------------------------------------------------------------

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/UserMapper.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/persistence/mappers/UserMapper.java
@@ -16,7 +16,6 @@ public interface UserMapper {
             expression = "java(user.getId() != null ? user.getId().toString() : null)")
     @Mapping(target = "isActive", source = "active")
     @Mapping(target = "roles", source = "roles")
-    @Mapping(target = "preferredLanguage", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     UserEntity domainToEntity(User user);
@@ -45,7 +44,6 @@ public interface UserMapper {
             expression = "java(user.getId() != null ? user.getId().toString() : null)")
     @Mapping(target = "isActive", source = "active")
     @Mapping(target = "roles", source = "roles")
-    @Mapping(target = "preferredLanguage", ignore = true)
     @Mapping(target = "createdAt", ignore = true)
     @Mapping(target = "updatedAt", ignore = true)
     void applyDomainToEntity(User user, @MappingTarget UserEntity entity);

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileHandlerTest.java
@@ -10,10 +10,10 @@ import com.iyte_yazilim.proje_pazari.application.common.ResponseCode;
 import com.iyte_yazilim.proje_pazari.application.dtos.UserDto;
 import com.iyte_yazilim.proje_pazari.application.mappers.UserDtoMapper;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.entities.User;
 import com.iyte_yazilim.proje_pazari.domain.events.UserUpdatedEvent;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.UserNotFoundException;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
-import com.iyte_yazilim.proje_pazari.infrastructure.persistence.models.UserEntity;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IUserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +27,7 @@ import org.springframework.context.ApplicationEventPublisher;
 @ExtendWith(MockitoExtension.class)
 class UpdateUserProfileHandlerTest {
 
-    @Mock private UserRepository userRepository;
+    @Mock private IUserRepository userRepository;
 
     @Mock private UserDtoMapper userDtoMapper;
 
@@ -56,6 +56,7 @@ class UpdateUserProfileHandlerTest {
     void shouldUpdateProfile_whenAllFieldsProvided() {
         // Given
         String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
         UpdateUserProfileCommand command =
                 new UpdateUserProfileCommand(
                         userId,
@@ -66,11 +67,10 @@ class UpdateUserProfileHandlerTest {
                         "https://github.com/johndoe",
                         "en");
 
-        UserEntity userEntity = new UserEntity();
-        userEntity.setId(userId);
-        userEntity.setEmail("john@std.iyte.edu.tr");
-        userEntity.setFirstName("OldFirstName");
-        userEntity.setLastName("OldLastName");
+        User user =
+                new User("john@std.iyte.edu.tr", "hashedPassword", "OldFirstName", "OldLastName");
+        user.setId(ulid);
+        user.setPreferredLanguage("tr");
 
         UserDto expectedDto =
                 new UserDto(
@@ -84,9 +84,9 @@ class UpdateUserProfileHandlerTest {
                         "https://github.com/johndoe",
                         "en");
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
-        when(userRepository.save(userEntity)).thenReturn(userEntity);
-        when(userDtoMapper.toDto(userEntity)).thenReturn(expectedDto);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
 
         // When
         ApiResponse<UserDto> response = handler.handle(command);
@@ -98,7 +98,11 @@ class UpdateUserProfileHandlerTest {
         assertEquals("John", response.getData().firstName());
         assertEquals("Doe", response.getData().lastName());
         assertEquals("Software Engineer", response.getData().description());
-        verify(userRepository).save(userEntity);
+        assertEquals("en", response.getData().preferredLanguage());
+        assertEquals("John", user.getFirstName());
+        assertEquals("Doe", user.getLastName());
+        assertEquals("en", user.getPreferredLanguage());
+        verify(userRepository).save(user);
         verify(applicationEventPublisher).publishEvent(any(UserUpdatedEvent.class));
     }
 
@@ -107,15 +111,15 @@ class UpdateUserProfileHandlerTest {
     void shouldUpdateProfile_whenPartialFieldsProvided() {
         // Given
         String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
         UpdateUserProfileCommand command =
                 new UpdateUserProfileCommand(userId, "NewFirstName", null, null, null, null, null);
 
-        UserEntity userEntity = new UserEntity();
-        userEntity.setId(userId);
-        userEntity.setEmail("user@std.iyte.edu.tr");
-        userEntity.setFirstName("OldFirstName");
-        userEntity.setLastName("OldLastName");
-        userEntity.setDescription("Old description");
+        User user =
+                new User("user@std.iyte.edu.tr", "hashedPassword", "OldFirstName", "OldLastName");
+        user.setId(ulid);
+        user.setDescription("Old description");
+        user.setPreferredLanguage("tr");
 
         UserDto expectedDto =
                 new UserDto(
@@ -127,21 +131,22 @@ class UpdateUserProfileHandlerTest {
                         null,
                         null,
                         null,
-                        null);
+                        "tr");
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
-        when(userRepository.save(userEntity)).thenReturn(userEntity);
-        when(userDtoMapper.toDto(userEntity)).thenReturn(expectedDto);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
 
         // When
         ApiResponse<UserDto> response = handler.handle(command);
 
         // Then
         assertEquals(ResponseCode.SUCCESS, response.getCode());
-        assertEquals("NewFirstName", userEntity.getFirstName());
-        assertEquals("OldLastName", userEntity.getLastName());
-        assertEquals("Old description", userEntity.getDescription());
-        verify(userRepository).save(userEntity);
+        assertEquals("NewFirstName", user.getFirstName());
+        assertEquals("OldLastName", user.getLastName());
+        assertEquals("Old description", user.getDescription());
+        assertEquals("tr", user.getPreferredLanguage());
+        verify(userRepository).save(user);
     }
 
     @Test
@@ -165,28 +170,29 @@ class UpdateUserProfileHandlerTest {
     void shouldSetUrlToNull_whenBlankUrlProvided() {
         // Given
         String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
         UpdateUserProfileCommand command =
                 new UpdateUserProfileCommand(userId, null, null, null, "   ", "   ", null);
 
-        UserEntity userEntity = new UserEntity();
-        userEntity.setId(userId);
-        userEntity.setLinkedinUrl("https://www.linkedin.com/in/old");
-        userEntity.setGithubUrl("https://github.com/old");
+        User user = new User("user@std.iyte.edu.tr", "hashedPassword", "First", "Last");
+        user.setId(ulid);
+        user.setLinkedinUrl("https://www.linkedin.com/in/old");
+        user.setGithubUrl("https://github.com/old");
 
         UserDto expectedDto = new UserDto(userId, null, null, null, null, null, null, null, null);
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
-        when(userRepository.save(userEntity)).thenReturn(userEntity);
-        when(userDtoMapper.toDto(userEntity)).thenReturn(expectedDto);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
 
         // When
         ApiResponse<UserDto> response = handler.handle(command);
 
         // Then
         assertEquals(ResponseCode.SUCCESS, response.getCode());
-        assertNull(userEntity.getLinkedinUrl());
-        assertNull(userEntity.getGithubUrl());
-        verify(userRepository).save(userEntity);
+        assertNull(user.getLinkedinUrl());
+        assertNull(user.getGithubUrl());
+        verify(userRepository).save(user);
     }
 
     @Test
@@ -194,6 +200,7 @@ class UpdateUserProfileHandlerTest {
     void shouldAcceptValidLinkedInUrl_withWww() {
         // Given
         String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
         UpdateUserProfileCommand command =
                 new UpdateUserProfileCommand(
                         userId,
@@ -204,8 +211,8 @@ class UpdateUserProfileHandlerTest {
                         null,
                         null);
 
-        UserEntity userEntity = new UserEntity();
-        userEntity.setId(userId);
+        User user = new User("user@std.iyte.edu.tr", "hashedPassword", "First", "Last");
+        user.setId(ulid);
 
         UserDto expectedDto =
                 new UserDto(
@@ -219,16 +226,16 @@ class UpdateUserProfileHandlerTest {
                         null,
                         null);
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
-        when(userRepository.save(userEntity)).thenReturn(userEntity);
-        when(userDtoMapper.toDto(userEntity)).thenReturn(expectedDto);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
 
         // When
         ApiResponse<UserDto> response = handler.handle(command);
 
         // Then
         assertEquals(ResponseCode.SUCCESS, response.getCode());
-        assertEquals("https://www.linkedin.com/in/johndoe", userEntity.getLinkedinUrl());
+        assertEquals("https://www.linkedin.com/in/johndoe", user.getLinkedinUrl());
     }
 
     @Test
@@ -236,12 +243,13 @@ class UpdateUserProfileHandlerTest {
     void shouldAcceptValidLinkedInUrl_withoutWww() {
         // Given
         String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
         UpdateUserProfileCommand command =
                 new UpdateUserProfileCommand(
                         userId, null, null, null, "https://linkedin.com/in/johndoe", null, null);
 
-        UserEntity userEntity = new UserEntity();
-        userEntity.setId(userId);
+        User user = new User("user@std.iyte.edu.tr", "hashedPassword", "First", "Last");
+        user.setId(ulid);
 
         UserDto expectedDto =
                 new UserDto(
@@ -255,16 +263,16 @@ class UpdateUserProfileHandlerTest {
                         null,
                         null);
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
-        when(userRepository.save(userEntity)).thenReturn(userEntity);
-        when(userDtoMapper.toDto(userEntity)).thenReturn(expectedDto);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
 
         // When
         ApiResponse<UserDto> response = handler.handle(command);
 
         // Then
         assertEquals(ResponseCode.SUCCESS, response.getCode());
-        assertEquals("https://linkedin.com/in/johndoe", userEntity.getLinkedinUrl());
+        assertEquals("https://linkedin.com/in/johndoe", user.getLinkedinUrl());
     }
 
     @Test
@@ -272,12 +280,13 @@ class UpdateUserProfileHandlerTest {
     void shouldAcceptValidGithubUrl_withPath() {
         // Given
         String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
         UpdateUserProfileCommand command =
                 new UpdateUserProfileCommand(
                         userId, null, null, null, null, "https://github.com/johndoe/my-repo", null);
 
-        UserEntity userEntity = new UserEntity();
-        userEntity.setId(userId);
+        User user = new User("user@std.iyte.edu.tr", "hashedPassword", "First", "Last");
+        user.setId(ulid);
 
         UserDto expectedDto =
                 new UserDto(
@@ -291,15 +300,91 @@ class UpdateUserProfileHandlerTest {
                         "https://github.com/johndoe/my-repo",
                         null);
 
-        when(userRepository.findById(userId)).thenReturn(Optional.of(userEntity));
-        when(userRepository.save(userEntity)).thenReturn(userEntity);
-        when(userDtoMapper.toDto(userEntity)).thenReturn(expectedDto);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
 
         // When
         ApiResponse<UserDto> response = handler.handle(command);
 
         // Then
         assertEquals(ResponseCode.SUCCESS, response.getCode());
-        assertEquals("https://github.com/johndoe/my-repo", userEntity.getGithubUrl());
+        assertEquals("https://github.com/johndoe/my-repo", user.getGithubUrl());
+    }
+
+    @Test
+    @DisplayName("Should update preferredLanguage when provided")
+    void shouldUpdatePreferredLanguage_whenProvided() {
+        // Given
+        String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(userId, null, null, null, null, null, "en");
+
+        User user = new User("user@std.iyte.edu.tr", "hashedPassword", "First", "Last");
+        user.setId(ulid);
+        user.setPreferredLanguage("tr");
+
+        UserDto expectedDto =
+                new UserDto(
+                        userId,
+                        "user@std.iyte.edu.tr",
+                        "First",
+                        "Last",
+                        null,
+                        null,
+                        null,
+                        null,
+                        "en");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
+
+        // When
+        ApiResponse<UserDto> response = handler.handle(command);
+
+        // Then
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals("en", user.getPreferredLanguage());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    @DisplayName("Should not update preferredLanguage when null")
+    void shouldNotUpdatePreferredLanguage_whenNull() {
+        // Given
+        String userId = Ulid.fast().toString();
+        Ulid ulid = Ulid.from(userId);
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(userId, "NewFirst", null, null, null, null, null);
+
+        User user = new User("user@std.iyte.edu.tr", "hashedPassword", "First", "Last");
+        user.setId(ulid);
+        user.setPreferredLanguage("tr");
+
+        UserDto expectedDto =
+                new UserDto(
+                        userId,
+                        "user@std.iyte.edu.tr",
+                        "NewFirst",
+                        "Last",
+                        null,
+                        null,
+                        null,
+                        null,
+                        "tr");
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.save(user)).thenReturn(user);
+        when(userDtoMapper.domainToDto(user)).thenReturn(expectedDto);
+
+        // When
+        ApiResponse<UserDto> response = handler.handle(command);
+
+        // Then
+        assertEquals(ResponseCode.SUCCESS, response.getCode());
+        assertEquals("tr", user.getPreferredLanguage());
+        verify(userRepository).save(user);
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileValidatorTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/updateUserProfile/UpdateUserProfileValidatorTest.java
@@ -1,0 +1,158 @@
+package com.iyte_yazilim.proje_pazari.application.commands.updateUserProfile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.github.f4b6a3.ulid.Ulid;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class UpdateUserProfileValidatorTest {
+
+    private final UpdateUserProfileValidator validator = new UpdateUserProfileValidator();
+
+    @Test
+    @DisplayName("Should return no errors for valid command")
+    void shouldReturnNoErrors_whenCommandIsValid() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(),
+                        "John",
+                        "Doe",
+                        "desc",
+                        "https://www.linkedin.com/in/johndoe",
+                        "https://github.com/johndoe",
+                        "en");
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(0, errors.length);
+    }
+
+    @Test
+    @DisplayName("Should return no errors when preferredLanguage is null")
+    void shouldReturnNoErrors_whenPreferredLanguageIsNull() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(), "John", "Doe", null, null, null, null);
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(0, errors.length);
+    }
+
+    @Test
+    @DisplayName("Should return error for unsupported preferredLanguage")
+    void shouldReturnError_whenPreferredLanguageIsUnsupported() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(), "John", "Doe", null, null, null, "es");
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(1, errors.length);
+        assertTrue(errors[0].contains("Invalid preferred language"));
+    }
+
+    @Test
+    @DisplayName("Should return error for blank preferredLanguage")
+    void shouldReturnError_whenPreferredLanguageIsBlank() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(), "John", "Doe", null, null, null, "");
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(1, errors.length);
+        assertTrue(errors[0].contains("Invalid preferred language"));
+    }
+
+    @Test
+    @DisplayName("Should return error for oversized preferredLanguage")
+    void shouldReturnError_whenPreferredLanguageIsTooLong() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(), "John", "Doe", null, null, null, "english");
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(1, errors.length);
+        assertTrue(errors[0].contains("Invalid preferred language"));
+    }
+
+    @Test
+    @DisplayName("Should accept 'tr' as preferredLanguage")
+    void shouldReturnNoErrors_whenPreferredLanguageIsTr() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(), "John", "Doe", null, null, null, "tr");
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(0, errors.length);
+    }
+
+    @Test
+    @DisplayName("Should return error for invalid LinkedIn URL")
+    void shouldReturnError_whenLinkedInUrlIsInvalid() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(),
+                        null,
+                        null,
+                        null,
+                        "http://linkedin.com/in/johndoe",
+                        null,
+                        null);
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(1, errors.length);
+        assertTrue(errors[0].contains("LinkedIn"));
+    }
+
+    @Test
+    @DisplayName("Should return error for invalid GitHub URL")
+    void shouldReturnError_whenGithubUrlIsInvalid() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(),
+                        null,
+                        null,
+                        null,
+                        null,
+                        "http://github.com/johndoe",
+                        null);
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(1, errors.length);
+        assertTrue(errors[0].contains("GitHub"));
+    }
+
+    @Test
+    @DisplayName("Should return multiple errors when both URL and language are invalid")
+    void shouldReturnMultipleErrors_whenMultipleFieldsInvalid() {
+        UpdateUserProfileCommand command =
+                new UpdateUserProfileCommand(
+                        Ulid.fast().toString(),
+                        null,
+                        null,
+                        null,
+                        "invalid-url",
+                        "invalid-url",
+                        "invalid");
+
+        String[] errors = validator.validate(command);
+
+        assertNotNull(errors);
+        assertEquals(3, errors.length);
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getCurrentUserProfile/GetCurrentUserProfileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getCurrentUserProfile/GetCurrentUserProfileHandlerTest.java
@@ -45,6 +45,7 @@ class GetCurrentUserProfileHandlerTest {
                         null,
                         null,
                         null,
+                        null,
                         LocalDateTime.now(),
                         0,
                         0,

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandlerTest.java
@@ -66,6 +66,7 @@ class GetUserProfileHandlerTest {
         user.setFirstName("John");
         user.setLastName("Doe");
         user.setDescription("Developer");
+        user.setPreferredLanguage("en");
         user.setCreatedAt(LocalDateTime.of(2024, 1, 1, 0, 0));
 
         ProjectEntity project = new ProjectEntity();
@@ -91,6 +92,7 @@ class GetUserProfileHandlerTest {
         assertEquals("John", response.getData().firstName());
         assertEquals("Doe", response.getData().lastName());
         assertEquals("John Doe", response.getData().fullName());
+        assertEquals("en", response.getData().preferredLanguage());
         assertEquals(1, response.getData().projectsCreated());
         assertEquals(2, response.getData().applicationsSubmitted());
         assertEquals(1, response.getData().projects().size());


### PR DESCRIPTION
## Summary

- **Fixes #127**: `UpdateUserProfileHandler` now maps `preferredLanguage` from the command to the entity, so the value is actually persisted.
- **Fixes #139**: Refactored handler to use `IUserRepository` (domain interface) instead of `UserRepository` (JPA) — removes persistence leak from the application layer. Added `preferredLanguage` field to domain `User` entity intentionally.

## Changes

- `domain/entities/User.java` — Added `preferredLanguage` field and setter
- `UpdateUserProfileHandler.java` — Refactored to use `IUserRepository` + domain `User`; added `preferredLanguage` mapping
- `UserMapper.java` — Removed `@Mapping(ignore=true)` for `preferredLanguage` in both `domainToEntity()` and `applyDomainToEntity()`
- `UserDtoMapper.java` — Removed `@Mapping(ignore=true)` for `preferredLanguage` in `domainToDto()`
- `UpdateUserProfileHandlerTest.java` — Refactored to mock `IUserRepository`; added 2 new tests for preferredLanguage update/null behavior

## Test plan

- [x] `./gradlew test --tests "...UpdateUserProfileHandlerTest"` — all 9 tests pass
- [x] `./gradlew spotlessCheck` — formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)