### PR TITLE
Refactor/issue 136 remove confirm password

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/resetPassword/ResetPasswordCommand.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/commands/resetPassword/ResetPasswordCommand.java
@@ -2,14 +2,11 @@ package com.iyte_yazilim.proje_pazari.application.commands.resetPassword;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.ICommand;
-import com.iyte_yazilim.proje_pazari.application.validators.PasswordMatches;
 import com.iyte_yazilim.proje_pazari.application.validators.ValidPassword;
-import com.iyte_yazilim.proje_pazari.domain.interfaces.PasswordMatchable;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 @Schema(description = "Command to reset a user's password using a reset token")
-@PasswordMatches
 public record ResetPasswordCommand(
         @Schema(description = "Password reset token received by email")
                 @NotBlank(message = "Reset token is required")
@@ -17,8 +14,5 @@ public record ResetPasswordCommand(
         @Schema(description = "New password", example = "NewSecurePass1!")
                 @NotBlank(message = "New password is required")
                 @ValidPassword
-                String newPassword,
-        @Schema(description = "New password confirmation")
-                @NotBlank(message = "Password confirmation is required")
-                String confirmPassword)
-        implements ICommand<ApiResponse<Void>>, PasswordMatchable {}
+                String newPassword)
+        implements ICommand<ApiResponse<Void>> {}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/resetPassword/ResetPasswordHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/commands/resetPassword/ResetPasswordHandlerTest.java
@@ -92,7 +92,7 @@ class ResetPasswordHandlerTest {
         when(passwordEncoder.encode(VALID_PASSWORD)).thenReturn("new-hashed-password");
 
         ApiResponse<Void> response =
-                handler.handle(new ResetPasswordCommand(TOKEN, VALID_PASSWORD, VALID_PASSWORD));
+                handler.handle(new ResetPasswordCommand(TOKEN, VALID_PASSWORD));
 
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertEquals("new-hashed-password", user.getPassword());
@@ -107,10 +107,7 @@ class ResetPasswordHandlerTest {
 
         assertThrows(
                 InvalidVerificationTokenException.class,
-                () ->
-                        handler.handle(
-                                new ResetPasswordCommand(
-                                        "bad-token", VALID_PASSWORD, VALID_PASSWORD)));
+                () -> handler.handle(new ResetPasswordCommand("bad-token", VALID_PASSWORD)));
     }
 
     @Test
@@ -123,9 +120,7 @@ class ResetPasswordHandlerTest {
 
         assertThrows(
                 InvalidVerificationTokenException.class,
-                () ->
-                        handler.handle(
-                                new ResetPasswordCommand(TOKEN, VALID_PASSWORD, VALID_PASSWORD)));
+                () -> handler.handle(new ResetPasswordCommand(TOKEN, VALID_PASSWORD)));
     }
 
     @Test
@@ -138,9 +133,7 @@ class ResetPasswordHandlerTest {
 
         assertThrows(
                 VerificationTokenExpiredException.class,
-                () ->
-                        handler.handle(
-                                new ResetPasswordCommand(TOKEN, VALID_PASSWORD, VALID_PASSWORD)));
+                () -> handler.handle(new ResetPasswordCommand(TOKEN, VALID_PASSWORD)));
     }
 
     @Test
@@ -151,8 +144,6 @@ class ResetPasswordHandlerTest {
 
         assertThrows(
                 UserNotFoundException.class,
-                () ->
-                        handler.handle(
-                                new ResetPasswordCommand(TOKEN, VALID_PASSWORD, VALID_PASSWORD)));
+                () -> handler.handle(new ResetPasswordCommand(TOKEN, VALID_PASSWORD)));
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ResetPasswordIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ResetPasswordIntegrationTest.java
@@ -112,8 +112,6 @@ class ResetPasswordIntegrationTest {
                                                         "token",
                                                         tokenEntity.getToken(),
                                                         "newPassword",
-                                                        "NewSecurePassword123!",
-                                                        "confirmPassword",
                                                         "NewSecurePassword123!"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(0));
@@ -158,8 +156,6 @@ class ResetPasswordIntegrationTest {
                                                         "token",
                                                         "invalid-token",
                                                         "newPassword",
-                                                        "NewSecurePassword123!",
-                                                        "confirmPassword",
                                                         "NewSecurePassword123!"))))
                 .andExpect(status().isBadRequest());
     }
@@ -187,8 +183,7 @@ class ResetPasswordIntegrationTest {
         Map<String, String> resetRequest =
                 Map.of(
                         "token", tokenEntity.getToken(),
-                        "newPassword", "NewSecurePassword123!",
-                        "confirmPassword", "NewSecurePassword123!");
+                        "newPassword", "NewSecurePassword123!");
 
         // First reset — should succeed
         mockMvc.perform(
@@ -236,44 +231,7 @@ class ResetPasswordIntegrationTest {
                                                         "token",
                                                         tokenEntity.getToken(),
                                                         "newPassword",
-                                                        "NewSecurePassword123!",
-                                                        "confirmPassword",
                                                         "NewSecurePassword123!"))))
-                .andExpect(status().isBadRequest());
-    }
-
-    @Test
-    @DisplayName("POST /api/v1/auth/reset-password - should fail when passwords don't match")
-    void shouldReturn400_WhenPasswordsDontMatch() throws Exception {
-        String email = "reset-mismatch@std.iyte.edu.tr";
-        registerAndVerifyUser(email);
-
-        // Trigger forgot-password
-        mockMvc.perform(
-                post("/api/v1/auth/forgot-password")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(Map.of("email", email))));
-
-        // Retrieve token
-        String userId = userRepository.findByEmail(email).orElseThrow().getId();
-        PasswordResetTokenEntity tokenEntity =
-                passwordResetTokenRepository.findAll().stream()
-                        .filter(t -> t.getUserId().equals(userId))
-                        .findFirst()
-                        .orElseThrow();
-
-        mockMvc.perform(
-                        post("/api/v1/auth/reset-password")
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content(
-                                        objectMapper.writeValueAsString(
-                                                Map.of(
-                                                        "token",
-                                                        tokenEntity.getToken(),
-                                                        "newPassword",
-                                                        "NewSecurePassword123!",
-                                                        "confirmPassword",
-                                                        "DifferentPassword123!"))))
                 .andExpect(status().isBadRequest());
     }
 
@@ -306,8 +264,6 @@ class ResetPasswordIntegrationTest {
                                                         "token",
                                                         tokenEntity.getToken(),
                                                         "newPassword",
-                                                        "weak",
-                                                        "confirmPassword",
                                                         "weak"))))
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ResetPasswordIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/ResetPasswordIntegrationTest.java
@@ -181,9 +181,7 @@ class ResetPasswordIntegrationTest {
                         .orElseThrow();
 
         Map<String, String> resetRequest =
-                Map.of(
-                        "token", tokenEntity.getToken(),
-                        "newPassword", "NewSecurePassword123!");
+                Map.of("token", tokenEntity.getToken(), "newPassword", "NewSecurePassword123!");
 
         // First reset — should succeed
         mockMvc.perform(


### PR DESCRIPTION
This pull request simplifies the password reset functionality by removing the requirement for password confirmation during the reset process. The changes affect the command object, related validators, and both unit and integration tests to reflect this streamlined approach.

**Password Reset Command Simplification:**

* Removed the `confirmPassword` field and the `@PasswordMatches` validation from the `ResetPasswordCommand` record, so users now only need to provide the new password and reset token. (`ResetPasswordCommand.java`)

**Test Updates:**

* Updated all relevant unit tests in `ResetPasswordHandlerTest` to use the new `ResetPasswordCommand` constructor without the `confirmPassword` argument. [[1]](diffhunk://#diff-4e70c3cc0ff786b6bfb3d8cc687808467de4d7fcd8dcb9122fa020a0ba253275L95-R95) [[2]](diffhunk://#diff-4e70c3cc0ff786b6bfb3d8cc687808467de4d7fcd8dcb9122fa020a0ba253275L110-R110) [[3]](diffhunk://#diff-4e70c3cc0ff786b6bfb3d8cc687808467de4d7fcd8dcb9122fa020a0ba253275L126-R123) [[4]](diffhunk://#diff-4e70c3cc0ff786b6bfb3d8cc687808467de4d7fcd8dcb9122fa020a0ba253275L141-R136) [[5]](diffhunk://#diff-4e70c3cc0ff786b6bfb3d8cc687808467de4d7fcd8dcb9122fa020a0ba253275L154-R147)
* Updated integration tests in `ResetPasswordIntegrationTest` to remove the `confirmPassword` field from requests and deleted the test that checked for mismatched passwords, since that scenario is no longer applicable. [[1]](diffhunk://#diff-a05038b5088938795a6b1b90d03003ecdd340923a3425b765d2e726af446b4a0L115-L116) [[2]](diffhunk://#diff-a05038b5088938795a6b1b90d03003ecdd340923a3425b765d2e726af446b4a0L161-L162) [[3]](diffhunk://#diff-a05038b5088938795a6b1b90d03003ecdd340923a3425b765d2e726af446b4a0L188-R184) [[4]](diffhunk://#diff-a05038b5088938795a6b1b90d03003ecdd340923a3425b765d2e726af446b4a0L239-L279) [[5]](diffhunk://#diff-a05038b5088938795a6b1b90d03003ecdd340923a3425b765d2e726af446b4a0L309-L310)