### PR TITLE
fix(openapi): declare multipart file field as binary schema

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -76,10 +77,24 @@ public class FileController extends BaseController {
             description = "Uploads a new file. Requires authentication.",
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
                             content =
                                     @Content(
                                             mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
-                                            schema = @Schema(type = "object"),
+                                            schema =
+                                                    @Schema(
+                                                            type = "object",
+                                                            requiredProperties = {"file"}),
+                                            schemaProperties = {
+                                                @SchemaProperty(
+                                                        name = "file",
+                                                        schema =
+                                                                @Schema(
+                                                                        type = "string",
+                                                                        format = "binary",
+                                                                        description =
+                                                                                "File to upload"))
+                                            },
                                             encoding =
                                                     @io.swagger.v3.oas.annotations.media.Encoding(
                                                             name = "file",
@@ -119,12 +134,7 @@ public class FileController extends BaseController {
                         description = "Internal server error")
             })
     public ResponseEntity<ApiResponse<Map<String, Object>>> uploadFile(
-            @Parameter(
-                            description = "File to upload",
-                            required = true,
-                            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
-                    @RequestParam("file")
-                    MultipartFile file) {
+            @RequestParam("file") MultipartFile file) {
         return send(UploadFileCommand.class, null, null, null, null, Map.of("file", file));
     }
 }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserController.java
@@ -136,13 +136,25 @@ public class UserController extends BaseController {
             description = "Uploads a new profile picture for the authenticated user",
             requestBody =
                     @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                            required = true,
                             content =
                                     @io.swagger.v3.oas.annotations.media.Content(
                                             mediaType = "multipart/form-data",
                                             schema =
                                                     @io.swagger.v3.oas.annotations.media.Schema(
                                                             type = "object",
-                                                            implementation = Object.class),
+                                                            requiredProperties = {"file"}),
+                                            schemaProperties = {
+                                                @io.swagger.v3.oas.annotations.media.SchemaProperty(
+                                                        name = "file",
+                                                        schema =
+                                                                @io.swagger.v3.oas.annotations.media
+                                                                        .Schema(
+                                                                        type = "string",
+                                                                        format = "binary",
+                                                                        description =
+                                                                                "Profile picture file (JPEG, PNG, GIF, or WebP)"))
+                                            },
                                             encoding =
                                                     @io.swagger.v3.oas.annotations.media.Encoding(
                                                             name = "file",
@@ -161,15 +173,7 @@ public class UserController extends BaseController {
                         description = "Unauthorized")
             })
     public ResponseEntity<ApiResponse<String>> uploadProfilePicture(
-            @io.swagger.v3.oas.annotations.Parameter(
-                            description = "Profile picture file to upload",
-                            required = true,
-                            content =
-                                    @io.swagger.v3.oas.annotations.media.Content(
-                                            mediaType = "multipart/form-data"))
-                    @RequestParam("file")
-                    MultipartFile file,
-            Authentication auth) {
+            @RequestParam("file") MultipartFile file, Authentication auth) {
         return send(
                 UploadProfilePictureCommand.class, null, null, null, auth, Map.of("file", file));
     }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/config/OpenApiMultipartSchemaTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/config/OpenApiMultipartSchemaTest.java
@@ -1,0 +1,57 @@
+package com.iyte_yazilim.proje_pazari.presentation.config;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class OpenApiMultipartSchemaTest extends IntegrationTestBase {
+
+    @Nested
+    @DisplayName("POST /api/v1/users/me/profile-picture - OpenAPI schema")
+    class ProfilePictureSchemaTests {
+
+        private static final String CONTENT_PATH =
+                "$.paths['/api/v1/users/me/profile-picture'].post.requestBody"
+                        + ".content['multipart/form-data']";
+
+        @Test
+        @DisplayName("declares file as required string/binary, not a generic object")
+        void declaresFileAsRequiredBinary() throws Exception {
+            mockMvc.perform(get("/v3/api-docs"))
+                    .andExpect(status().isOk())
+                    .andExpect(
+                            jsonPath(CONTENT_PATH + ".schema.properties.file.type").value("string"))
+                    .andExpect(
+                            jsonPath(CONTENT_PATH + ".schema.properties.file.format")
+                                    .value("binary"))
+                    .andExpect(jsonPath(CONTENT_PATH + ".schema.required").value(hasItem("file")));
+        }
+    }
+
+    @Nested
+    @DisplayName("POST /api/v1/files - OpenAPI schema")
+    class FileUploadSchemaTests {
+
+        private static final String CONTENT_PATH =
+                "$.paths['/api/v1/files'].post.requestBody.content['multipart/form-data']";
+
+        @Test
+        @DisplayName("declares file as required string/binary, not a generic object")
+        void declaresFileAsRequiredBinary() throws Exception {
+            mockMvc.perform(get("/v3/api-docs"))
+                    .andExpect(status().isOk())
+                    .andExpect(
+                            jsonPath(CONTENT_PATH + ".schema.properties.file.type").value("string"))
+                    .andExpect(
+                            jsonPath(CONTENT_PATH + ".schema.properties.file.format")
+                                    .value("binary"))
+                    .andExpect(jsonPath(CONTENT_PATH + ".schema.required").value(hasItem("file")));
+        }
+    }
+}


### PR DESCRIPTION
Profile-picture and file-upload endpoints described their multipart body as a generic object, so Swagger UI couldn't render a file picker. Add an explicit required file property (type: string, format: binary) and a contract test asserting it against /v3/api-docs.

Closes #153