### PR TITLE
refactor(user): standardize user ID field as userId in UserProfileDTO

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/dtos/UserProfileDTO.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/dtos/UserProfileDTO.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 @Schema(description = "Comprehensive user profile data transfer object")
 public record UserProfileDTO(
-        @Schema(description = "User ID", example = "01HQZX9K2M3N4P5Q6R7S8T9V0W") String id,
+        @Schema(description = "User ID", example = "01HQZX9K2M3N4P5Q6R7S8T9V0W") String userId,
         @Schema(description = "Email address", example = "user@example.com") String email,
         @Schema(description = "First name", example = "John") String firstName,
         @Schema(description = "Last name", example = "Doe") String lastName,

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getCurrentUserProfile/GetCurrentUserProfileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getCurrentUserProfile/GetCurrentUserProfileHandlerTest.java
@@ -64,7 +64,7 @@ class GetCurrentUserProfileHandlerTest {
         // Then
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertNotNull(response.getData());
-        assertEquals(authenticatedUserId, response.getData().id());
+        assertEquals(authenticatedUserId, response.getData().userId());
 
         // Verify delegation with correct user ID
         ArgumentCaptor<GetUserProfileQuery> captor =

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/getUserProfile/GetUserProfileHandlerTest.java
@@ -87,7 +87,7 @@ class GetUserProfileHandlerTest {
         // Then
         assertEquals(ResponseCode.SUCCESS, response.getCode());
         assertNotNull(response.getData());
-        assertEquals(userId, response.getData().id());
+        assertEquals(userId, response.getData().userId());
         assertEquals("test@std.iyte.edu.tr", response.getData().email());
         assertEquals("John", response.getData().firstName());
         assertEquals("Doe", response.getData().lastName());

--- a/src/test/java/com/iyte_yazilim/proje_pazari/e2e/UserJourneyE2ETest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/e2e/UserJourneyE2ETest.java
@@ -109,7 +109,7 @@ class UserJourneyE2ETest {
     void step3_viewProfile() throws Exception {
         mockMvc.perform(get("/api/v1/users/me").header("Authorization", "Bearer " + jwtToken))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(userId))
+                .andExpect(jsonPath("$.data.userId").value(userId))
                 .andExpect(jsonPath("$.data.firstName").value("E2E"))
                 .andExpect(jsonPath("$.data.lastName").value("Tester"));
     }
@@ -140,7 +140,7 @@ class UserJourneyE2ETest {
     void step5_viewPublicProfile() throws Exception {
         mockMvc.perform(get("/api/v1/users/{userId}", userId))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.data.id").value(userId))
+                .andExpect(jsonPath("$.data.userId").value(userId))
                 .andExpect(jsonPath("$.data.firstName").value("Updated"));
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/config/OpenApiUserIdSchemaTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/config/OpenApiUserIdSchemaTest.java
@@ -1,0 +1,35 @@
+package com.iyte_yazilim.proje_pazari.presentation.config;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("OpenAPI - user ID field is standardized as userId")
+class OpenApiUserIdSchemaTest extends IntegrationTestBase {
+
+    private static final String SCHEMAS = "$.components.schemas";
+
+    @Test
+    @DisplayName("UserProfileDTO exposes userId and no longer exposes id")
+    void userProfileDtoExposesUserId() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(SCHEMAS + ".UserProfileDTO.properties.userId").exists())
+                .andExpect(jsonPath(SCHEMAS + ".UserProfileDTO.properties.id").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("Other user DTOs continue to use userId")
+    void otherUserDtosUseUserId() throws Exception {
+        mockMvc.perform(get("/v3/api-docs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath(SCHEMAS + ".UserDto.properties.userId").exists())
+                .andExpect(jsonPath(SCHEMAS + ".UserDto.properties.id").doesNotExist())
+                .andExpect(jsonPath(SCHEMAS + ".UserAdminDTO.properties.userId").exists())
+                .andExpect(jsonPath(SCHEMAS + ".UserAdminDTO.properties.id").doesNotExist());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/UserControllerIntegrationTest.java
@@ -86,7 +86,7 @@ class UserControllerIntegrationTest extends IntegrationTestBase {
 
             mockMvc.perform(get(BASE_URL + "/" + userId))
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.data.id").value(userId))
+                    .andExpect(jsonPath("$.data.userId").value(userId))
                     .andExpect(jsonPath("$.data.email").value(VALID_EMAIL))
                     .andExpect(jsonPath("$.data.firstName").value(VALID_FIRST_NAME))
                     .andExpect(jsonPath("$.data.lastName").value(VALID_LAST_NAME))


### PR DESCRIPTION
Closes #134

## Problem

User DTOs exposed the same concept under two different JSON keys:

| DTO | Field before | Field after |
|---|---|---|
| `UserDto` | `userId` | `userId` (unchanged) |
| `UserAdminDTO` | `userId` | `userId` (unchanged) |
| `UserProfileDTO` | `id` | **`userId`** |

Since these are Java `record`s serialized straight to JSON, the component name *is* the API contract. `GET /api/v1/users/{userId}` and `GET /api/v1/users/me` returned `data.id`, while every other user-shaped response returned `data.userId` — forcing the frontend to branch on which endpoint it called to read the same value.

Per the issue decision, `userId` is canonical.

## Changes

- `UserProfileDTO`: renamed record component `id` → `userId`.
- Construction is positional, so `GetUserProfileHandler` needed no change — `user.getId()` was already the first argument. No production logic moved; only the accessor name and the wire contract.
- Updated the two `.id()` accessor call sites and the three `jsonPath("$.data.id")` assertions.
- Added `OpenApiUserIdSchemaTest` (following the existing `OpenApiMultipartSchemaTest` pattern): asserts against `/v3/api-docs` that `UserProfileDTO` exposes `userId` and no longer exposes `id`, and that `UserDto` / `UserAdminDTO` still use `userId`. This verifies the OpenAPI acceptance criteria against the generated spec rather than assuming springdoc follows the component name, and guards against regression.

## Breaking change

This renames a field on the profile endpoints' responses. Per discussion, nothing is in production yet, so no consumer is affected and no deprecation window / `@JsonProperty` alias was added.

## Acceptance criteria

- [x] `UserProfileDTO` uses `userId` instead of `id`
- [x] User profile response mappings updated (no change required — positional construction)
- [x] Swagger/OpenAPI output reflects the updated contract — verified by the new test
- [x] Other user DTOs continue to use `userId` — covered by the new test
- [x] Existing user profile behavior continues to work
- [x] Relevant tests updated

## Testing

Full suite: **972 tests, 0 failures, 0 errors** (4 pre-existing skips). Spotless applied with no reformatting needed.