### PR TITLE
fix(files): serve local storage downloads inline instead of redirecting to the same API URL

### DIFF
--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCode.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/common/ErrorCode.java
@@ -101,6 +101,9 @@ public enum ErrorCode {
     /** A file storage operation failed. */
     FILE_STORAGE_ERROR(ResponseCode.INTERNAL_SERVER_ERROR, "error.internal"),
 
+    /** The requested file does not exist in the storage backend. */
+    FILE_NOT_FOUND(ResponseCode.NOT_FOUND, "file.not.found"),
+
     // --- Domain state errors ---
     /** A user lifecycle method was invoked from an invalid current state. */
     ILLEGAL_USER_STATE(ResponseCode.CONFLICT, "user.illegal.state"),

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandler.java
@@ -3,7 +3,6 @@ package com.iyte_yazilim.proje_pazari.application.queries.downloadFile;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
-import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -56,13 +55,14 @@ public class DownloadFileHandler
             return ApiResponse.notFound("File not found");
         }
 
-        try {
-            StorageDownloadResult result =
-                    fileStorageService.getDownloadResult(normalizedPath, DEFAULT_EXPIRY_MINUTES);
-            return ApiResponse.success(result, "File resolved successfully");
-        } catch (FileValidationException e) {
-            return ApiResponse.badRequest(e.getMessage());
-        }
+        // Left to propagate deliberately: DomainException carries its own ErrorCode, which
+        // GlobalExceptionHandler turns into the right status and a localized, user-safe message.
+        // Catching it here to rewrap e.getMessage() would leak the technical message — including
+        // the storage path — into the response body, and would flatten a file that vanished
+        // between the check above and this read (404) into a 400.
+        StorageDownloadResult result =
+                fileStorageService.getDownloadResult(normalizedPath, DEFAULT_EXPIRY_MINUTES);
+        return ApiResponse.success(result, "File resolved successfully");
     }
 
     /**

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandler.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandler.java
@@ -3,6 +3,8 @@ package com.iyte_yazilim.proje_pazari.application.queries.downloadFile;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequestHandler;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -12,7 +14,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class DownloadFileHandler
-        implements IRequestHandler<DownloadFileQuery, ApiResponse<String>> {
+        implements IRequestHandler<DownloadFileQuery, ApiResponse<StorageDownloadResult>> {
 
     private static final int DEFAULT_EXPIRY_MINUTES = 60;
     private static final int MAX_DECODE_ITERATIONS = 5;
@@ -20,7 +22,7 @@ public class DownloadFileHandler
     private final FileStorageService fileStorageService;
 
     @Override
-    public ApiResponse<String> handle(DownloadFileQuery query) {
+    public ApiResponse<StorageDownloadResult> handle(DownloadFileQuery query) {
         String rawPath = query.path();
 
         if (rawPath == null || rawPath.isBlank()) {
@@ -54,8 +56,13 @@ public class DownloadFileHandler
             return ApiResponse.notFound("File not found");
         }
 
-        String presignedUrl = fileStorageService.getFileUrl(normalizedPath, DEFAULT_EXPIRY_MINUTES);
-        return ApiResponse.success(presignedUrl, "File URL generated successfully");
+        try {
+            StorageDownloadResult result =
+                    fileStorageService.getDownloadResult(normalizedPath, DEFAULT_EXPIRY_MINUTES);
+            return ApiResponse.success(result, "File resolved successfully");
+        } catch (FileValidationException e) {
+            return ApiResponse.badRequest(e.getMessage());
+        }
     }
 
     /**

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileQuery.java
@@ -2,5 +2,6 @@ package com.iyte_yazilim.proje_pazari.application.queries.downloadFile;
 
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 
-public record DownloadFileQuery(String path) implements IRequest<ApiResponse<String>> {}
+public record DownloadFileQuery(String path) implements IRequest<ApiResponse<StorageDownloadResult>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileQuery.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileQuery.java
@@ -4,4 +4,5 @@ import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IRequest;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 
-public record DownloadFileQuery(String path) implements IRequest<ApiResponse<StorageDownloadResult>> {}
+public record DownloadFileQuery(String path)
+        implements IRequest<ApiResponse<StorageDownloadResult>> {}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageService.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageService.java
@@ -9,6 +9,8 @@ import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,31 @@ import org.springframework.web.multipart.MultipartFile;
 @Service
 @RequiredArgsConstructor
 public class FileStorageService {
+
+    /**
+     * Canonical extension for each content type the upload boundary accepts.
+     *
+     * <p>The stored extension is derived from the validated content type instead of being kept from
+     * the client-supplied filename. Only the declared multipart content type is validated, so a
+     * filename is free to disagree with it: an upload named "avatar.html" declaring "image/jpeg"
+     * would otherwise be stored with its active extension intact and handed back by the public
+     * download endpoint as HTML.
+     */
+    private static final Map<String, String> CANONICAL_EXTENSIONS =
+            Map.of(
+                    "image/jpeg", ".jpg",
+                    "image/png", ".png",
+                    "image/gif", ".gif",
+                    "image/webp", ".webp",
+                    "application/pdf", ".pdf");
+
+    /**
+     * Extension for an allowed content type with no canonical mapping above, which is reachable by
+     * widening {@code storage.allowed-content-types}. Deliberately opaque rather than rejected, so
+     * extending the configuration does not start failing uploads; the real content type is still
+     * recorded by the storage adapter.
+     */
+    private static final String OPAQUE_EXTENSION = ".bin";
 
     private final IFileStorageAdapter storageAdapter;
 
@@ -44,7 +71,7 @@ public class FileStorageService {
     public String storeFile(MultipartFile file, String directory) {
         validateFile(file);
 
-        String fileName = generateUniqueFileName(file.getOriginalFilename());
+        String fileName = generateUniqueFileName(file);
         String path = directory + "/" + fileName;
 
         return storageAdapter.store(toFileUpload(file), path);
@@ -59,7 +86,7 @@ public class FileStorageService {
         validateFile(file);
         validateStorageKeyPart(userId, "userId");
 
-        String extension = getFileExtension(file.getOriginalFilename());
+        String extension = storedExtension(file);
         String objectName = "users/" + userId + "/avatar" + extension;
         return storageAdapter.store(toFileUpload(file), avatarsBucket + "/" + objectName);
     }
@@ -74,7 +101,7 @@ public class FileStorageService {
         validateStorageKeyPart(projectId, "projectId");
         validateStorageKeyPart(documentId, "documentId");
 
-        String extension = getFileExtension(file.getOriginalFilename());
+        String extension = storedExtension(file);
         String objectName = "projects/" + projectId + "/" + documentId + extension;
         return storageAdapter.store(toFileUpload(file), documentsBucket + "/" + objectName);
     }
@@ -153,22 +180,31 @@ public class FileStorageService {
     }
 
     /**
-     * Generates a unique file name.
+     * Generates a unique file name, carrying the extension that matches the file's validated
+     * content type.
      *
-     * @param originalFilename the original file name
+     * @param file the file being stored, already validated
      * @return the unique file name
      */
-    private String generateUniqueFileName(String originalFilename) {
-        String extension = getFileExtension(originalFilename);
+    private String generateUniqueFileName(MultipartFile file) {
         String ulid = UlidCreator.getUlid().toString();
-        return ulid + extension;
+        return ulid + storedExtension(file);
     }
 
-    private String getFileExtension(String filename) {
-        if (filename != null && filename.contains(".")) {
-            return filename.substring(filename.lastIndexOf("."));
+    /**
+     * Maps the file's validated content type to the extension it will be stored under. Must be
+     * called only after {@link #validateFile(MultipartFile)}, which is what establishes that the
+     * content type is one the application accepts.
+     */
+    private String storedExtension(MultipartFile file) {
+        String contentType = file.getContentType();
+        if (contentType == null) {
+            return OPAQUE_EXTENSION;
         }
-        return "";
+
+        // Parameters (e.g. "image/jpeg;charset=binary") are not part of the type identity.
+        String bareType = contentType.split(";")[0].trim().toLowerCase(Locale.ROOT);
+        return CANONICAL_EXTENSIONS.getOrDefault(bareType, OPAQUE_EXTENSION);
     }
 
     private void validateStorageKeyPart(String value, String fieldName) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageService.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageService.java
@@ -6,6 +6,7 @@ import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -84,6 +85,23 @@ public class FileStorageService {
 
     public String getFileUrl(String filePath) {
         return storageAdapter.generatePresignedUrl(filePath, 60);
+    }
+
+    /**
+     * Resolves how a file at {@code path} should be delivered to a client. Delegates to the
+     * configured {@link IFileStorageAdapter}, which decides between a redirect (e.g. MinIO/S3
+     * presigned URL) or inline content (e.g. local disk) — see {@link StorageDownloadResult}.
+     * Reuses the same path validation as {@link #deleteFile(String)} / {@link
+     * #getFileMetadata(String)}, so traversal and malformed paths are rejected identically
+     * regardless of the download strategy the adapter chooses.
+     *
+     * @param path the file path
+     * @param expirationMinutes URL validity duration, used only when the adapter redirects
+     * @return the resolved download result
+     */
+    public StorageDownloadResult getDownloadResult(String path, int expirationMinutes) {
+        validatePath(path);
+        return storageAdapter.resolveDownload(path, expirationMinutes);
     }
 
     /**

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/StoredFileNotFoundException.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/exceptions/StoredFileNotFoundException.java
@@ -1,0 +1,18 @@
+package com.iyte_yazilim.proje_pazari.domain.exceptions;
+
+import com.iyte_yazilim.proje_pazari.application.common.ErrorCode;
+
+/**
+ * A file was requested that does not exist in the configured storage backend.
+ *
+ * <p>Distinct from {@link FileValidationException} so a file that is simply missing maps to 404
+ * rather than 400 — the two are reachable from the same call when a file disappears between an
+ * existence check and the read that follows.
+ *
+ * <p>Named to avoid colliding with {@code java.io.FileNotFoundException}.
+ */
+public class StoredFileNotFoundException extends DomainException {
+    public StoredFileNotFoundException(String path) {
+        super(ErrorCode.FILE_NOT_FOUND, "File not found: " + path);
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IFileStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IFileStorageAdapter.java
@@ -3,7 +3,6 @@ package com.iyte_yazilim.proje_pazari.domain.interfaces;
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
-
 import java.util.List;
 
 /**
@@ -59,15 +58,16 @@ public interface IFileStorageAdapter {
      * pre-signed/public URL: it wraps {@link #generatePresignedUrl(String, int)} in a {@link
      * StorageDownloadResult.RedirectResult}. Adapters that cannot produce an externally
      * redirectable URL (e.g. local filesystem storage) must override this method and return a
-     * {@link StorageDownloadResult.InlineResult} instead, to avoid the caller redirecting to a
-     * URL that points back at itself.
+     * {@link StorageDownloadResult.InlineResult} instead, to avoid the caller redirecting to a URL
+     * that points back at itself.
      *
      * @param path the file path
      * @param expirationMinutes URL validity duration, relevant only for redirect-capable adapters
      * @return a {@link StorageDownloadResult} describing how to deliver the file
      */
     default StorageDownloadResult resolveDownload(String path, int expirationMinutes) {
-        return new StorageDownloadResult.RedirectResult(generatePresignedUrl(path, expirationMinutes));
+        return new StorageDownloadResult.RedirectResult(
+                generatePresignedUrl(path, expirationMinutes));
     }
 
     /** Checks whether the storage backend is reachable and operational. */

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IFileStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/interfaces/IFileStorageAdapter.java
@@ -2,6 +2,8 @@ package com.iyte_yazilim.proje_pazari.domain.interfaces;
 
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
+
 import java.util.List;
 
 /**
@@ -49,6 +51,24 @@ public interface IFileStorageAdapter {
      * @return file metadata
      */
     FileMetadata getMetadata(String path);
+
+    /**
+     * Resolves how a file should be delivered to the client for download.
+     *
+     * <p>The default implementation preserves existing behavior for adapters that expose a
+     * pre-signed/public URL: it wraps {@link #generatePresignedUrl(String, int)} in a {@link
+     * StorageDownloadResult.RedirectResult}. Adapters that cannot produce an externally
+     * redirectable URL (e.g. local filesystem storage) must override this method and return a
+     * {@link StorageDownloadResult.InlineResult} instead, to avoid the caller redirecting to a
+     * URL that points back at itself.
+     *
+     * @param path the file path
+     * @param expirationMinutes URL validity duration, relevant only for redirect-capable adapters
+     * @return a {@link StorageDownloadResult} describing how to deliver the file
+     */
+    default StorageDownloadResult resolveDownload(String path, int expirationMinutes) {
+        return new StorageDownloadResult.RedirectResult(generatePresignedUrl(path, expirationMinutes));
+    }
 
     /** Checks whether the storage backend is reachable and operational. */
     default boolean isAvailable() {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/models/StorageDownloadResult.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/models/StorageDownloadResult.java
@@ -1,0 +1,19 @@
+package com.iyte_yazilim.proje_pazari.domain.models;
+
+/**
+ * Represents the outcome of resolving a file for download. Providers that expose a
+ * pre-signed/public URL (e.g. MinIO/S3) should return {@link RedirectResult}. Providers that
+ * cannot generate an externally-usable URL (e.g. local filesystem) must return
+ * {@link InlineResult} so the controller can stream the bytes directly instead of redirecting
+ * to itself.
+ */
+public sealed interface StorageDownloadResult
+        permits StorageDownloadResult.RedirectResult, StorageDownloadResult.InlineResult {
+
+    /** Adapter can produce a redirectable URL (e.g. MinIO/S3 presigned URL). */
+    record RedirectResult(String url) implements StorageDownloadResult {}
+
+    /** Adapter cannot produce a redirectable URL; file content is returned inline instead. */
+    record InlineResult(byte[] content, String contentType, String filename)
+            implements StorageDownloadResult {}
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/domain/models/StorageDownloadResult.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/domain/models/StorageDownloadResult.java
@@ -2,10 +2,9 @@ package com.iyte_yazilim.proje_pazari.domain.models;
 
 /**
  * Represents the outcome of resolving a file for download. Providers that expose a
- * pre-signed/public URL (e.g. MinIO/S3) should return {@link RedirectResult}. Providers that
- * cannot generate an externally-usable URL (e.g. local filesystem) must return
- * {@link InlineResult} so the controller can stream the bytes directly instead of redirecting
- * to itself.
+ * pre-signed/public URL (e.g. MinIO/S3) should return {@link RedirectResult}. Providers that cannot
+ * generate an externally-usable URL (e.g. local filesystem) must return {@link InlineResult} so the
+ * controller can stream the bytes directly instead of redirecting to itself.
  */
 public sealed interface StorageDownloadResult
         permits StorageDownloadResult.RedirectResult, StorageDownloadResult.InlineResult {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/ContainedFileTree.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/ContainedFileTree.java
@@ -1,0 +1,395 @@
+package com.iyte_yazilim.proje_pazari.infrastructure.storage;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.SeekableByteChannel;
+import java.nio.file.DirectoryStream;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.NotDirectoryException;
+import java.nio.file.OpenOption;
+import java.nio.file.Path;
+import java.nio.file.SecureDirectoryStream;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.BasicFileAttributeView;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Reads and writes files strictly beneath a fixed root directory.
+ *
+ * <p>Containment is bound to the operation rather than to a pathname. Validating a path and then
+ * opening it is only a snapshot: the entry can be replaced with a symbolic link in between, and
+ * both {@link Files#write} and {@link Files#readAllBytes} follow links. Instead, every directory in
+ * the relative path is opened through its parent's descriptor with {@link
+ * LinkOption#NOFOLLOW_LINKS} (a {@link SecureDirectoryStream}), and the final entry is opened the
+ * same way, so the kernel — not an earlier check — rejects a link at the moment of use.
+ *
+ * <p>The rule is uniform: nothing inside local storage is reached through a symbolic link, whether
+ * it points outside the root or back into it. Stored files and their sidecars are written only by
+ * this application, so a link anywhere in the tree was planted by something else.
+ *
+ * <h2>Platforms without descriptor-relative traversal</h2>
+ *
+ * <p>{@link SecureDirectoryStream} is optional; the Linux and macOS default providers supply it,
+ * Windows does not. Where it is unavailable this falls back to pathname operations that still apply
+ * the no-follow policy to every component, which closes the same holes for a link that is already
+ * in place but leaves a narrow window in which an ancestor swapped mid-operation could be followed.
+ * The fallback is logged once at startup.
+ *
+ * <h2>Hard links: outside the guarantee</h2>
+ *
+ * <p>A hard link is an ordinary directory entry, indistinguishable from the file it names, so
+ * neither no-follow opens nor real-path resolution can tell that the inode also has a name outside
+ * the root. Someone able to create a hard link inside the storage directory — which requires local
+ * write access there and a target on the same filesystem — can therefore expose that file's
+ * contents through this adapter. Rejecting entries with a link count above one was considered and
+ * dropped: snapshot and dedup tooling (for example {@code rsync --link-dest}) raises the count on
+ * legitimate files and would break every download. Local storage is a development provider; the
+ * containment guarantee here covers traversal and symbolic links and assumes nothing hostile can
+ * write into the storage tree.
+ */
+@Slf4j
+final class ContainedFileTree {
+
+    /** Signals that an entry is not storage-owned: it is, or became, a symbolic link. */
+    static final class ContainmentException extends IOException {
+        ContainmentException(String message) {
+            super(message);
+        }
+    }
+
+    private static final Set<OpenOption> READ = Set.of(StandardOpenOption.READ);
+
+    private static final Set<OpenOption> REPLACE =
+            Set.of(
+                    StandardOpenOption.WRITE,
+                    StandardOpenOption.CREATE,
+                    StandardOpenOption.TRUNCATE_EXISTING);
+
+    /** The root with symbolic links resolved; every traversal starts from this directory. */
+    private final Path root;
+
+    private final boolean descriptorRelative;
+
+    ContainedFileTree(Path root) throws IOException {
+        this.root = root.toRealPath();
+        this.descriptorRelative = supportsDescriptorRelativeTraversal(this.root);
+
+        if (!descriptorRelative) {
+            log.warn(
+                    "Descriptor-relative directory traversal is unavailable at {}; local storage"
+                            + " falls back to pathname operations with a no-follow policy",
+                    this.root);
+        }
+    }
+
+    byte[] readAllBytes(Path relative) throws IOException {
+        try (Cursor cursor = openParent(relative, false)) {
+            String name = fileName(relative);
+            rejectSymbolicLink(cursor, name, true);
+
+            try (SeekableByteChannel channel = open(cursor, name, READ)) {
+                return Channels.newInputStream(channel).readAllBytes();
+            }
+        }
+    }
+
+    void write(Path relative, byte[] content) throws IOException {
+        try (Cursor cursor = openParent(relative, true)) {
+            String name = fileName(relative);
+            rejectSymbolicLink(cursor, name, false);
+
+            try (SeekableByteChannel channel = open(cursor, name, REPLACE)) {
+                channel.write(ByteBuffer.wrap(content));
+            }
+        }
+    }
+
+    /**
+     * Removes the entry if it exists. A symbolic link is refused rather than unlinked: this adapter
+     * never creates one, so removing it would quietly clean up someone else's plant and hide that
+     * the tree was tampered with.
+     */
+    boolean deleteIfExists(Path relative) throws IOException {
+        try (Cursor cursor = openParent(relative, false)) {
+            String name = fileName(relative);
+            if (!rejectSymbolicLink(cursor, name, false)) {
+                return false;
+            }
+
+            cursor.delete(name);
+            return true;
+        } catch (NoSuchFileException e) {
+            return false;
+        }
+    }
+
+    /** Attributes of the entry itself, never of a symbolic link's target. */
+    BasicFileAttributes readAttributes(Path relative) throws IOException {
+        try (Cursor cursor = openParent(relative, false)) {
+            String name = fileName(relative);
+            rejectSymbolicLink(cursor, name, true);
+            return cursor.attributes(name);
+        }
+    }
+
+    /** Whether a storage-owned entry exists; a symbolic link counts as absent, not present. */
+    boolean exists(Path relative) {
+        try {
+            readAttributes(relative);
+            return true;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Rejects an entry that is currently a symbolic link, reporting whether it exists at all. This
+     * is a classification step, not the guard: the no-follow open that follows is what actually
+     * prevents a link from being traversed, including one planted after this check.
+     */
+    private boolean rejectSymbolicLink(Cursor cursor, String name, boolean requireExisting)
+            throws IOException {
+        BasicFileAttributes attributes;
+        try {
+            attributes = cursor.attributes(name);
+        } catch (NoSuchFileException e) {
+            if (requireExisting) {
+                throw e;
+            }
+            return false;
+        }
+
+        if (attributes.isSymbolicLink()) {
+            throw new ContainmentException(
+                    "Refusing to follow a symbolic link inside local storage: " + name);
+        }
+        return true;
+    }
+
+    private SeekableByteChannel open(Cursor cursor, String name, Set<OpenOption> options)
+            throws IOException {
+        try {
+            return cursor.open(name, noFollow(options));
+        } catch (NoSuchFileException e) {
+            throw e;
+        } catch (IOException e) {
+            // A no-follow open of a symbolic link lands here — the case this whole class exists
+            // for, an entry swapped after it was classified. The JDK reports it as a plain
+            // IOException (ELOOP) with no distinguishable type, so every failure that is not
+            // "missing" is treated as a containment violation: this adapter opens only files it
+            // wrote itself, and failing closed is the safe direction for the ones it did not.
+            throw new ContainmentException(
+                    "Refusing to open an entry that changed during the operation: " + name);
+        }
+    }
+
+    /** Opens the directory that immediately contains {@code relative}, creating it when asked. */
+    private Cursor openParent(Path relative, boolean createMissing) throws IOException {
+        Path parent = relative.getParent();
+
+        if (!descriptorRelative) {
+            return new PathCursor(walkByPathname(parent, createMissing));
+        }
+
+        SecureDirectoryStream<Path> stream = openRoot();
+        try {
+            Path absolute = root;
+            for (Path component : componentsOf(parent)) {
+                absolute = absolute.resolve(component.toString());
+                SecureDirectoryStream<Path> child =
+                        openDirectory(stream, component.toString(), absolute, createMissing);
+                stream.close();
+                stream = child;
+            }
+            return new SecureCursor(stream);
+        } catch (IOException e) {
+            stream.close();
+            throw e;
+        }
+    }
+
+    /**
+     * Descends one level through the parent's descriptor. Missing directories are created by
+     * pathname because Java exposes no descriptor-relative {@code mkdir}; the result is immediately
+     * re-opened through the parent descriptor with no-follow, so a raced ancestor can at worst
+     * leave a stray empty directory and never divert a file read or write out of the root.
+     */
+    private SecureDirectoryStream<Path> openDirectory(
+            SecureDirectoryStream<Path> parent, String name, Path absolute, boolean createMissing)
+            throws IOException {
+        try {
+            return openChild(parent, name);
+        } catch (NoSuchFileException e) {
+            if (!createMissing) {
+                throw e;
+            }
+        }
+
+        try {
+            Files.createDirectory(absolute);
+        } catch (FileAlreadyExistsException e) {
+            // Lost a benign race with a concurrent upload into the same directory.
+        }
+        return openChild(parent, name);
+    }
+
+    private SecureDirectoryStream<Path> openChild(SecureDirectoryStream<Path> parent, String name)
+            throws IOException {
+        BasicFileAttributes attributes =
+                parent.getFileAttributeView(
+                                Path.of(name),
+                                BasicFileAttributeView.class,
+                                LinkOption.NOFOLLOW_LINKS)
+                        .readAttributes();
+
+        if (attributes.isSymbolicLink()) {
+            throw new ContainmentException(
+                    "Refusing to traverse a symbolic link inside local storage: " + name);
+        }
+        if (!attributes.isDirectory()) {
+            throw new NotDirectoryException(name);
+        }
+
+        try {
+            return parent.newDirectoryStream(Path.of(name), LinkOption.NOFOLLOW_LINKS);
+        } catch (NoSuchFileException e) {
+            throw e;
+        } catch (IOException e) {
+            // Same reasoning as open(): a link swapped in after the check fails here untyped.
+            throw new ContainmentException(
+                    "Refusing to traverse an entry that changed during the operation: " + name);
+        }
+    }
+
+    /** Fallback traversal: same no-follow policy, applied to pathnames instead of descriptors. */
+    private Path walkByPathname(Path parent, boolean createMissing) throws IOException {
+        Path directory = root;
+        for (Path component : componentsOf(parent)) {
+            directory = directory.resolve(component.toString());
+
+            if (createMissing) {
+                try {
+                    Files.createDirectory(directory);
+                } catch (FileAlreadyExistsException e) {
+                    // Already there, or lost a benign race; validated just below either way.
+                }
+            }
+
+            BasicFileAttributes attributes =
+                    Files.readAttributes(
+                            directory, BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+            if (attributes.isSymbolicLink()) {
+                throw new ContainmentException(
+                        "Refusing to traverse a symbolic link inside local storage: " + directory);
+            }
+            if (!attributes.isDirectory()) {
+                throw new NotDirectoryException(directory.toString());
+            }
+        }
+        return directory;
+    }
+
+    private SecureDirectoryStream<Path> openRoot() throws IOException {
+        DirectoryStream<Path> stream = Files.newDirectoryStream(root);
+        if (stream instanceof SecureDirectoryStream<Path> secure) {
+            return secure;
+        }
+        stream.close();
+        throw new IOException("Storage root no longer supports descriptor-relative traversal");
+    }
+
+    private static boolean supportsDescriptorRelativeTraversal(Path root) {
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(root)) {
+            return stream instanceof SecureDirectoryStream;
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private static Iterable<Path> componentsOf(Path parent) {
+        return parent == null ? Set.of() : parent;
+    }
+
+    private static String fileName(Path relative) {
+        Path name = relative.getFileName();
+        if (name == null) {
+            throw new IllegalArgumentException("Path has no file name: " + relative);
+        }
+        return name.toString();
+    }
+
+    private static Set<OpenOption> noFollow(Set<OpenOption> options) {
+        Set<OpenOption> withNoFollow = new HashSet<>(options);
+        withNoFollow.add(LinkOption.NOFOLLOW_LINKS);
+        return withNoFollow;
+    }
+
+    /** A handle on the directory that immediately contains the entry being operated on. */
+    private interface Cursor extends Closeable {
+
+        SeekableByteChannel open(String name, Set<OpenOption> options) throws IOException;
+
+        BasicFileAttributes attributes(String name) throws IOException;
+
+        void delete(String name) throws IOException;
+    }
+
+    /** Descriptor-relative: operations cannot be redirected by anything above the directory. */
+    private record SecureCursor(SecureDirectoryStream<Path> stream) implements Cursor {
+
+        @Override
+        public SeekableByteChannel open(String name, Set<OpenOption> options) throws IOException {
+            return stream.newByteChannel(Path.of(name), options);
+        }
+
+        @Override
+        public BasicFileAttributes attributes(String name) throws IOException {
+            return stream.getFileAttributeView(
+                            Path.of(name), BasicFileAttributeView.class, LinkOption.NOFOLLOW_LINKS)
+                    .readAttributes();
+        }
+
+        @Override
+        public void delete(String name) throws IOException {
+            stream.deleteFile(Path.of(name));
+        }
+
+        @Override
+        public void close() throws IOException {
+            stream.close();
+        }
+    }
+
+    /** Pathname fallback for providers without {@link SecureDirectoryStream}. */
+    private record PathCursor(Path directory) implements Cursor {
+
+        @Override
+        public SeekableByteChannel open(String name, Set<OpenOption> options) throws IOException {
+            return Files.newByteChannel(directory.resolve(name), options);
+        }
+
+        @Override
+        public BasicFileAttributes attributes(String name) throws IOException {
+            return Files.readAttributes(
+                    directory.resolve(name), BasicFileAttributes.class, LinkOption.NOFOLLOW_LINKS);
+        }
+
+        @Override
+        public void delete(String name) throws IOException {
+            Files.delete(directory.resolve(name));
+        }
+
+        @Override
+        public void close() {
+            // Nothing is held open.
+        }
+    }
+}

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
@@ -140,12 +140,13 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
             throw new FileValidationException("Failed to retrieve file", e);
         }
     }
+
     /**
      * Reads the file directly from disk and returns it as an {@link
-     * StorageDownloadResult.InlineResult}, since local storage has no externally redirectable
-     * URL to offer. This is the fix for the infinite-redirect bug: previously {@link
-     * #generatePresignedUrl(String, int)} was reused for downloads and returned a URL pointing
-     * back at this same API endpoint.
+     * StorageDownloadResult.InlineResult}, since local storage has no externally redirectable URL
+     * to offer. This is the fix for the infinite-redirect bug: previously {@link
+     * #generatePresignedUrl(String, int)} was reused for downloads and returned a URL pointing back
+     * at this same API endpoint.
      */
     @Override
     public StorageDownloadResult resolveDownload(String path, int expirationMinutes) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
@@ -2,6 +2,7 @@ package com.iyte_yazilim.proje_pazari.infrastructure.storage;
 
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.StoredFileNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
@@ -15,7 +16,9 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaTypeFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.util.MimeType;
 
 /**
  * Local file system storage implementation for development without external storage. Active when
@@ -25,6 +28,8 @@ import org.springframework.stereotype.Component;
 @Component
 @ConditionalOnProperty(name = "storage.provider", havingValue = "local")
 public class LocalStorageAdapter implements IFileStorageAdapter {
+
+    private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
     private final Path storageLocation;
 
@@ -95,49 +100,20 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
 
     @Override
     public FileMetadata getMetadata(String path) {
+        Path filePath = resolveExistingFile(path);
         try {
-            Path filePath = storageLocation.resolve(path).normalize();
-
-            if (!filePath.startsWith(storageLocation)) {
-                throw new FileValidationException("Invalid file path - path traversal detected");
-            }
-
-            if (!Files.exists(filePath)) {
-                throw new FileValidationException("File not found: " + path);
-            }
-
             BasicFileAttributes attrs = Files.readAttributes(filePath, BasicFileAttributes.class);
-            String contentType = Files.probeContentType(filePath);
 
             return new FileMetadata(
                     path,
                     attrs.size(),
-                    contentType != null ? contentType : "application/octet-stream",
+                    resolveContentType(filePath),
                     attrs.creationTime().toInstant(),
                     attrs.lastModifiedTime().toInstant(),
                     filePath.getFileName().toString(),
                     null);
         } catch (IOException e) {
             throw new FileStorageException("Failed to get file metadata", e);
-        }
-    }
-
-    /** Retrieves file content as bytes. Used internally for serving files. */
-    public byte[] retrieveAsBytes(String path) {
-        try {
-            Path filePath = storageLocation.resolve(path).normalize();
-
-            if (!filePath.startsWith(storageLocation)) {
-                throw new FileValidationException("Invalid file path - path traversal detected");
-            }
-
-            if (!Files.exists(filePath)) {
-                throw new FileValidationException("File not found: " + path);
-            }
-
-            return Files.readAllBytes(filePath);
-        } catch (IOException e) {
-            throw new FileValidationException("Failed to retrieve file", e);
         }
     }
 
@@ -150,38 +126,58 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
      */
     @Override
     public StorageDownloadResult resolveDownload(String path, int expirationMinutes) {
-        Path filePath = storageLocation.resolve(path).normalize();
-
-        // Security: same traversal guard used by store/delete/exists/getMetadata
-        if (!filePath.startsWith(storageLocation)) {
-            throw new FileValidationException("Invalid file path - path traversal detected");
-        }
-
-        if (!Files.exists(filePath) || !Files.isRegularFile(filePath)) {
-            throw new FileValidationException("File not found: " + path);
-        }
+        Path filePath = resolveExistingFile(path);
 
         try {
-            byte[] content = Files.readAllBytes(filePath);
-            String contentType = Files.probeContentType(filePath);
-            if (contentType == null || contentType.isBlank()) {
-                contentType = "application/octet-stream";
-            }
-
-            String filename = safeFilename(filePath.getFileName().toString());
-
-            return new StorageDownloadResult.InlineResult(content, contentType, filename);
+            return new StorageDownloadResult.InlineResult(
+                    Files.readAllBytes(filePath),
+                    resolveContentType(filePath),
+                    filePath.getFileName().toString());
         } catch (IOException e) {
             throw new FileStorageException("Failed to read local file", e);
         }
     }
 
-    /** Strips characters that could enable HTTP header injection via Content-Disposition. */
-    private String safeFilename(String rawName) {
-        if (rawName == null || rawName.isBlank()) {
-            return "download";
+    /**
+     * Resolves a caller-supplied relative path to a real file inside the storage root, applying the
+     * single traversal guard shared by every read operation.
+     */
+    private Path resolveExistingFile(String path) {
+        Path filePath = storageLocation.resolve(path).normalize();
+
+        if (!filePath.startsWith(storageLocation)) {
+            throw new FileValidationException("Invalid file path - path traversal detected");
         }
-        return rawName.replaceAll("[\\r\\n\"\\\\]", "_");
+
+        if (!Files.exists(filePath) || !Files.isRegularFile(filePath)) {
+            throw new StoredFileNotFoundException(path);
+        }
+
+        return filePath;
+    }
+
+    /**
+     * Determines the content type from the filename extension first, falling back to the platform's
+     * probe. Extension mapping is used in preference because {@link Files#probeContentType}
+     * consults host-specific databases (e.g. /etc/mime.types) and returns null on minimal
+     * containers, which would otherwise make the served content type depend on where the app
+     * happens to run.
+     */
+    private String resolveContentType(Path filePath) {
+        String fileName = filePath.getFileName().toString();
+        return MediaTypeFactory.getMediaType(fileName)
+                .map(MimeType::toString)
+                .orElseGet(
+                        () -> {
+                            try {
+                                String probed = Files.probeContentType(filePath);
+                                return probed != null && !probed.isBlank()
+                                        ? probed
+                                        : DEFAULT_CONTENT_TYPE;
+                            } catch (IOException e) {
+                                return DEFAULT_CONTENT_TYPE;
+                            }
+                        });
     }
 
     @Override

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
@@ -8,6 +8,7 @@ import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
@@ -15,6 +16,7 @@ import java.nio.file.Files;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Properties;
@@ -296,12 +298,16 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
 
     private String readContentTypeSidecar(Path filePath) {
         Path sidecar = metadataPathFor(filePath);
-        if (!Files.isRegularFile(sidecar)) {
+        if (!isAdapterOwnedSidecar(sidecar)
+                || !Files.isRegularFile(sidecar, LinkOption.NOFOLLOW_LINKS)) {
             return null;
         }
 
         Properties recorded = new Properties();
-        try (Reader reader = Files.newBufferedReader(sidecar, StandardCharsets.UTF_8)) {
+        try (Reader reader =
+                new InputStreamReader(
+                        Files.newInputStream(sidecar, LinkOption.NOFOLLOW_LINKS),
+                        StandardCharsets.UTF_8)) {
             recorded.load(reader);
         } catch (IOException e) {
             log.warn("Failed to read stored content type for {}: {}", filePath, e.getMessage());
@@ -320,20 +326,62 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
      */
     private void writeContentTypeSidecar(Path filePath, String contentType) {
         Path sidecar = metadataPathFor(filePath);
+
+        if (!isAdapterOwnedSidecar(sidecar)) {
+            log.warn("Refused to record content type through a non-adapter path: {}", sidecar);
+            return;
+        }
+
         try {
             if (contentType == null || contentType.isBlank()) {
+                // Removes the link itself rather than its target: deleteIfExists does not follow
+                // symbolic links.
                 Files.deleteIfExists(sidecar);
                 return;
             }
 
             Properties recorded = new Properties();
             recorded.setProperty(CONTENT_TYPE_KEY, contentType);
-            try (Writer writer = Files.newBufferedWriter(sidecar, StandardCharsets.UTF_8)) {
-                recorded.store(writer, "Content type validated at upload time");
-            }
+            replaceSidecar(sidecar, recorded);
         } catch (IOException e) {
             log.warn("Failed to record content type for {}: {}", filePath, e.getMessage());
         }
+    }
+
+    /**
+     * Writes the record to a temporary file in the sidecar's own (already contained) directory and
+     * moves it into place. The move replaces the sidecar entry itself, so a link planted between
+     * the containment check and the write cannot be followed out of the storage root — writing to
+     * the sidecar path directly would follow it.
+     *
+     * <p>The temporary file carries the reserved metadata suffix, so it is unreachable through the
+     * download endpoint for the moment it exists.
+     */
+    private void replaceSidecar(Path sidecar, Properties recorded) throws IOException {
+        Path parent = sidecar.getParent();
+        Path temp = Files.createTempFile(parent, ".tmp-", METADATA_SUFFIX);
+        try {
+            try (Writer writer = Files.newBufferedWriter(temp, StandardCharsets.UTF_8)) {
+                recorded.store(writer, "Content type validated at upload time");
+            }
+            Files.move(temp, sidecar, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            Files.deleteIfExists(temp);
+            throw e;
+        }
+    }
+
+    /**
+     * Reports whether a sidecar path is one this adapter may read or write. Sidecars are created
+     * only here, so a sidecar that is a symbolic link was planted by someone else and is rejected
+     * outright rather than resolved.
+     *
+     * <p>Checked separately from the file it describes: {@code avatar.jpg} and {@code
+     * avatar.jpg.meta} are distinct filesystem targets, so validating the former says nothing about
+     * the latter.
+     */
+    private boolean isAdapterOwnedSidecar(Path sidecar) {
+        return !Files.isSymbolicLink(sidecar) && isWithinStorageRoot(sidecar);
     }
 
     @Override

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
@@ -7,16 +7,19 @@ import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
+import com.iyte_yazilim.proje_pazari.infrastructure.storage.ContainedFileTree.ContainmentException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.nio.file.LinkOption;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
 import java.util.Properties;
@@ -30,6 +33,12 @@ import org.springframework.util.MimeType;
 /**
  * Local file system storage implementation for development without external storage. Active when
  * storage.provider=local
+ *
+ * <p>Caller-supplied paths are validated lexically here — traversal out of the root and the
+ * reserved sidecar suffix are rejected before anything touches the disk — while every actual read
+ * and write goes through {@link ContainedFileTree}, which binds containment to the open itself
+ * rather than to a pathname that could change afterwards. See that class for the guarantee's
+ * boundaries.
  */
 @Slf4j
 @Component
@@ -51,31 +60,12 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
     /** Lexical root: absolute and normalized, but symbolic links left unresolved. */
     private final Path storageLocation;
 
-    /**
-     * Same directory with every symbolic link resolved. Containment is checked against this, since
-     * {@link Path#normalize()} is pure string math and would accept a link inside the storage
-     * directory that points outside it. Held separately from {@link #storageLocation} because
-     * callers' relative paths are resolved lexically (no filesystem access) before being checked.
-     */
-    private final Path storageRoot;
+    private final ContainedFileTree tree;
 
     public LocalStorageAdapter(@Value("${storage.local.path:./uploads}") String storagePath) {
         this.storageLocation = Paths.get(storagePath).toAbsolutePath().normalize();
         createStorageDirectory();
-        this.storageRoot = resolveStorageRoot();
-    }
-
-    /**
-     * Resolves the real path of the storage root once at startup. The root itself is frequently a
-     * symbolic link (macOS {@code /tmp}, container mounts, JUnit temp dirs), so comparing candidate
-     * real paths against an unresolved root would reject every legitimate file.
-     */
-    private Path resolveStorageRoot() {
-        try {
-            return storageLocation.toRealPath();
-        } catch (IOException e) {
-            throw new FileStorageException("Failed to resolve storage directory", e);
-        }
+        this.tree = openStorageTree();
     }
 
     private void createStorageDirectory() {
@@ -87,38 +77,38 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
         }
     }
 
+    private ContainedFileTree openStorageTree() {
+        try {
+            return new ContainedFileTree(storageLocation);
+        } catch (IOException e) {
+            throw new FileStorageException("Failed to resolve storage directory", e);
+        }
+    }
+
     @Override
     public String store(FileUpload file, String path) {
+        Path relative = relativePathOf(path);
+
+        if (relative == null) {
+            throw new FileStorageException("Invalid file path - path traversal detected");
+        }
+        if (isMetadataPath(relative)) {
+            throw new FileStorageException("Invalid file path - reserved metadata suffix");
+        }
+
         try {
-            Path targetLocation = storageLocation.resolve(path).normalize();
-
-            // Security: Verify path is within storage location
-            if (!targetLocation.startsWith(storageLocation)) {
-                throw new FileStorageException("Invalid file path - path traversal detected");
-            }
-
-            if (isMetadataPath(targetLocation)) {
-                throw new FileStorageException("Invalid file path - reserved metadata suffix");
-            }
-
-            // Checked before createDirectories: if an existing ancestor is a link out of the
-            // root, creating directories through it would materialize them outside the root.
-            if (!isWithinStorageRoot(targetLocation)) {
-                throw new FileStorageException("Invalid file path - resolves outside storage root");
-            }
-
-            // Create parent directories if they don't exist
-            Files.createDirectories(targetLocation.getParent());
-
-            Files.write(targetLocation, file.bytes());
-            writeContentTypeSidecar(targetLocation, file.contentType());
-            log.debug("Stored file locally: {}", path);
-
-            // Return API path for local storage
-            return "/api/v1/files/" + path;
+            tree.write(relative, file.bytes());
+        } catch (ContainmentException e) {
+            throw new FileStorageException("Invalid file path - resolves outside storage root");
         } catch (IOException e) {
             throw new FileStorageException("Failed to store file locally", e);
         }
+
+        writeContentTypeSidecar(relative, file.contentType());
+        log.debug("Stored file locally: {}", path);
+
+        // Return API path for local storage
+        return "/api/v1/files/" + path;
     }
 
     @Override
@@ -129,54 +119,45 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
 
     @Override
     public void delete(String path) {
+        Path relative = relativePathOf(path);
+
+        if (relative == null || isMetadataPath(relative)) {
+            throw new FileValidationException("Invalid file path - path traversal detected");
+        }
+
         try {
-            Path filePath = storageLocation.resolve(path).normalize();
-
-            if (!filePath.startsWith(storageLocation) || isMetadataPath(filePath)) {
-                throw new FileValidationException("Invalid file path - path traversal detected");
-            }
-
-            if (!isWithinStorageRoot(filePath)) {
-                throw new FileValidationException(
-                        "Invalid file path - resolves outside storage root");
-            }
-
-            Files.deleteIfExists(filePath);
-            // Removed together with the file it describes, so a later upload to the same path
-            // cannot inherit the previous file's recorded content type.
-            Files.deleteIfExists(metadataPathFor(filePath));
-            log.debug("Deleted local file: {}", path);
+            tree.deleteIfExists(relative);
+        } catch (ContainmentException e) {
+            throw new FileValidationException("Invalid file path - resolves outside storage root");
         } catch (IOException e) {
             throw new FileStorageException("Failed to delete file", e);
         }
+
+        // Removed together with the file it describes, so a later upload to the same path
+        // cannot inherit the previous file's recorded content type.
+        deleteContentTypeSidecar(relative);
+        log.debug("Deleted local file: {}", path);
     }
 
     @Override
     public boolean exists(String path) {
-        Path filePath = storageLocation.resolve(path).normalize();
-        return filePath.startsWith(storageLocation)
-                && !isMetadataPath(filePath)
-                && isWithinStorageRoot(filePath)
-                && Files.exists(filePath);
+        Path relative = relativePathOf(path);
+        return relative != null && !isMetadataPath(relative) && tree.exists(relative);
     }
 
     @Override
     public FileMetadata getMetadata(String path) {
-        Path filePath = resolveExistingFile(path);
-        try {
-            BasicFileAttributes attrs = Files.readAttributes(filePath, BasicFileAttributes.class);
+        Path relative = requireStorableFile(path);
+        BasicFileAttributes attrs = readAttributes(relative, path);
 
-            return new FileMetadata(
-                    path,
-                    attrs.size(),
-                    resolveContentType(filePath),
-                    attrs.creationTime().toInstant(),
-                    attrs.lastModifiedTime().toInstant(),
-                    filePath.getFileName().toString(),
-                    null);
-        } catch (IOException e) {
-            throw new FileStorageException("Failed to get file metadata", e);
-        }
+        return new FileMetadata(
+                path,
+                attrs.size(),
+                resolveContentType(relative),
+                attrs.creationTime().toInstant(),
+                attrs.lastModifiedTime().toInstant(),
+                fileName(relative),
+                null);
     }
 
     /**
@@ -188,78 +169,81 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
      */
     @Override
     public StorageDownloadResult resolveDownload(String path, int expirationMinutes) {
-        Path filePath = resolveExistingFile(path);
+        Path relative = requireStorableFile(path);
+        readAttributes(relative, path);
 
         try {
             return new StorageDownloadResult.InlineResult(
-                    Files.readAllBytes(filePath),
-                    resolveContentType(filePath),
-                    filePath.getFileName().toString());
+                    tree.readAllBytes(relative), resolveContentType(relative), fileName(relative));
+        } catch (ContainmentException e) {
+            throw new FileValidationException("Invalid file path - resolves outside storage root");
+        } catch (NoSuchFileException e) {
+            throw new StoredFileNotFoundException(path);
         } catch (IOException e) {
             throw new FileStorageException("Failed to read local file", e);
         }
     }
 
     /**
-     * Resolves a caller-supplied relative path to a real file inside the storage root, applying the
-     * single traversal guard shared by every read operation.
+     * Applies the lexical guard shared by every read operation: the path must stay under the
+     * storage root and must not name a sidecar.
      */
-    private Path resolveExistingFile(String path) {
-        Path filePath = storageLocation.resolve(path).normalize();
+    private Path requireStorableFile(String path) {
+        Path relative = relativePathOf(path);
 
-        if (!filePath.startsWith(storageLocation)) {
+        if (relative == null) {
             throw new FileValidationException("Invalid file path - path traversal detected");
         }
 
         // Reported as missing rather than rejected: the sidecars are an implementation detail,
         // and a 404 does not disclose whether one exists.
-        if (isMetadataPath(filePath)) {
+        if (isMetadataPath(relative)) {
             throw new StoredFileNotFoundException(path);
         }
 
-        if (!isWithinStorageRoot(filePath)) {
+        return relative;
+    }
+
+    private BasicFileAttributes readAttributes(Path relative, String path) {
+        try {
+            BasicFileAttributes attrs = tree.readAttributes(relative);
+            if (!attrs.isRegularFile()) {
+                throw new StoredFileNotFoundException(path);
+            }
+            return attrs;
+        } catch (ContainmentException e) {
             throw new FileValidationException("Invalid file path - resolves outside storage root");
-        }
-
-        if (!Files.exists(filePath) || !Files.isRegularFile(filePath)) {
+        } catch (NoSuchFileException e) {
             throw new StoredFileNotFoundException(path);
+        } catch (IOException e) {
+            throw new FileStorageException("Failed to get file metadata", e);
         }
-
-        return filePath;
     }
 
     /**
-     * Reports whether {@code candidate} stays inside the storage root once symbolic links are
-     * resolved. Checked against the deepest ancestor that currently exists, so the answer is
-     * meaningful for a file that has not been written yet while still catching a linked ancestor.
-     *
-     * <p>Fails closed: an unreadable path is treated as outside the root rather than assumed safe.
+     * Resolves a caller-supplied path against the storage root and returns it relative to that
+     * root, or {@code null} when it escapes lexically. Pure string math — the filesystem-level
+     * guarantee is {@link ContainedFileTree}'s.
      */
-    private boolean isWithinStorageRoot(Path candidate) {
-        Path existing = candidate;
-        while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
-            existing = existing.getParent();
-        }
+    private Path relativePathOf(String path) {
+        Path resolved = storageLocation.resolve(path).normalize();
 
-        if (existing == null) {
-            return false;
+        if (!resolved.startsWith(storageLocation) || resolved.equals(storageLocation)) {
+            return null;
         }
-
-        try {
-            return existing.toRealPath().startsWith(storageRoot);
-        } catch (IOException e) {
-            log.warn("Failed to resolve real path for containment check: {}", e.getMessage());
-            return false;
-        }
+        return storageLocation.relativize(resolved);
     }
 
-    private boolean isMetadataPath(Path filePath) {
-        Path fileName = filePath.getFileName();
-        return fileName != null && fileName.toString().endsWith(METADATA_SUFFIX);
+    private boolean isMetadataPath(Path relative) {
+        return fileName(relative).endsWith(METADATA_SUFFIX);
     }
 
-    private Path metadataPathFor(Path filePath) {
-        return filePath.resolveSibling(filePath.getFileName().toString() + METADATA_SUFFIX);
+    private Path sidecarOf(Path relative) {
+        return relative.resolveSibling(fileName(relative) + METADATA_SUFFIX);
+    }
+
+    private String fileName(Path relative) {
+        return relative.getFileName().toString();
     }
 
     /**
@@ -274,45 +258,33 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
      * separately at the HTTP boundary, so neither a stale sidecar nor a hostile filename here can
      * turn a stored file into active content.
      */
-    private String resolveContentType(Path filePath) {
-        String recorded = readContentTypeSidecar(filePath);
+    private String resolveContentType(Path relative) {
+        String recorded = readContentTypeSidecar(relative);
         if (recorded != null && !recorded.isBlank()) {
             return recorded;
         }
 
-        String fileName = filePath.getFileName().toString();
-        return MediaTypeFactory.getMediaType(fileName)
+        return MediaTypeFactory.getMediaType(fileName(relative))
                 .map(MimeType::toString)
-                .orElseGet(
-                        () -> {
-                            try {
-                                String probed = Files.probeContentType(filePath);
-                                return probed != null && !probed.isBlank()
-                                        ? probed
-                                        : DEFAULT_CONTENT_TYPE;
-                            } catch (IOException e) {
-                                return DEFAULT_CONTENT_TYPE;
-                            }
-                        });
+                .orElse(DEFAULT_CONTENT_TYPE);
     }
 
-    private String readContentTypeSidecar(Path filePath) {
-        Path sidecar = metadataPathFor(filePath);
-        if (!isAdapterOwnedSidecar(sidecar)
-                || !Files.isRegularFile(sidecar, LinkOption.NOFOLLOW_LINKS)) {
+    private String readContentTypeSidecar(Path relative) {
+        Properties recorded = new Properties();
+
+        try (Reader reader =
+                new InputStreamReader(
+                        new ByteArrayInputStream(tree.readAllBytes(sidecarOf(relative))),
+                        StandardCharsets.UTF_8)) {
+            recorded.load(reader);
+        } catch (NoSuchFileException e) {
+            return null;
+        } catch (IOException e) {
+            // Includes a planted symbolic link at the sidecar path: not ours, so not read.
+            log.warn("Failed to read stored content type for {}: {}", relative, e.getMessage());
             return null;
         }
 
-        Properties recorded = new Properties();
-        try (Reader reader =
-                new InputStreamReader(
-                        Files.newInputStream(sidecar, LinkOption.NOFOLLOW_LINKS),
-                        StandardCharsets.UTF_8)) {
-            recorded.load(reader);
-        } catch (IOException e) {
-            log.warn("Failed to read stored content type for {}: {}", filePath, e.getMessage());
-            return null;
-        }
         return recorded.getProperty(CONTENT_TYPE_KEY);
     }
 
@@ -324,64 +296,32 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
      * downloads fall back to the extension mapping — which, for uploads that came through {@code
      * FileStorageService}, is itself derived from the validated content type.
      */
-    private void writeContentTypeSidecar(Path filePath, String contentType) {
-        Path sidecar = metadataPathFor(filePath);
-
-        if (!isAdapterOwnedSidecar(sidecar)) {
-            log.warn("Refused to record content type through a non-adapter path: {}", sidecar);
+    private void writeContentTypeSidecar(Path relative, String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            deleteContentTypeSidecar(relative);
             return;
         }
 
-        try {
-            if (contentType == null || contentType.isBlank()) {
-                // Removes the link itself rather than its target: deleteIfExists does not follow
-                // symbolic links.
-                Files.deleteIfExists(sidecar);
-                return;
-            }
+        Properties recorded = new Properties();
+        recorded.setProperty(CONTENT_TYPE_KEY, contentType);
 
-            Properties recorded = new Properties();
-            recorded.setProperty(CONTENT_TYPE_KEY, contentType);
-            replaceSidecar(sidecar, recorded);
-        } catch (IOException e) {
-            log.warn("Failed to record content type for {}: {}", filePath, e.getMessage());
-        }
-    }
-
-    /**
-     * Writes the record to a temporary file in the sidecar's own (already contained) directory and
-     * moves it into place. The move replaces the sidecar entry itself, so a link planted between
-     * the containment check and the write cannot be followed out of the storage root — writing to
-     * the sidecar path directly would follow it.
-     *
-     * <p>The temporary file carries the reserved metadata suffix, so it is unreachable through the
-     * download endpoint for the moment it exists.
-     */
-    private void replaceSidecar(Path sidecar, Properties recorded) throws IOException {
-        Path parent = sidecar.getParent();
-        Path temp = Files.createTempFile(parent, ".tmp-", METADATA_SUFFIX);
+        ByteArrayOutputStream buffer = new ByteArrayOutputStream();
         try {
-            try (Writer writer = Files.newBufferedWriter(temp, StandardCharsets.UTF_8)) {
+            try (Writer writer = new OutputStreamWriter(buffer, StandardCharsets.UTF_8)) {
                 recorded.store(writer, "Content type validated at upload time");
             }
-            Files.move(temp, sidecar, StandardCopyOption.REPLACE_EXISTING);
+            tree.write(sidecarOf(relative), buffer.toByteArray());
         } catch (IOException e) {
-            Files.deleteIfExists(temp);
-            throw e;
+            log.warn("Failed to record content type for {}: {}", relative, e.getMessage());
         }
     }
 
-    /**
-     * Reports whether a sidecar path is one this adapter may read or write. Sidecars are created
-     * only here, so a sidecar that is a symbolic link was planted by someone else and is rejected
-     * outright rather than resolved.
-     *
-     * <p>Checked separately from the file it describes: {@code avatar.jpg} and {@code
-     * avatar.jpg.meta} are distinct filesystem targets, so validating the former says nothing about
-     * the latter.
-     */
-    private boolean isAdapterOwnedSidecar(Path sidecar) {
-        return !Files.isSymbolicLink(sidecar) && isWithinStorageRoot(sidecar);
+    private void deleteContentTypeSidecar(Path relative) {
+        try {
+            tree.deleteIfExists(sidecarOf(relative));
+        } catch (IOException e) {
+            log.warn("Failed to remove stored content type for {}: {}", relative, e.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
@@ -5,6 +5,7 @@ import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -138,6 +139,48 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
         } catch (IOException e) {
             throw new FileValidationException("Failed to retrieve file", e);
         }
+    }
+    /**
+     * Reads the file directly from disk and returns it as an {@link
+     * StorageDownloadResult.InlineResult}, since local storage has no externally redirectable
+     * URL to offer. This is the fix for the infinite-redirect bug: previously {@link
+     * #generatePresignedUrl(String, int)} was reused for downloads and returned a URL pointing
+     * back at this same API endpoint.
+     */
+    @Override
+    public StorageDownloadResult resolveDownload(String path, int expirationMinutes) {
+        Path filePath = storageLocation.resolve(path).normalize();
+
+        // Security: same traversal guard used by store/delete/exists/getMetadata
+        if (!filePath.startsWith(storageLocation)) {
+            throw new FileValidationException("Invalid file path - path traversal detected");
+        }
+
+        if (!Files.exists(filePath) || !Files.isRegularFile(filePath)) {
+            throw new FileValidationException("File not found: " + path);
+        }
+
+        try {
+            byte[] content = Files.readAllBytes(filePath);
+            String contentType = Files.probeContentType(filePath);
+            if (contentType == null || contentType.isBlank()) {
+                contentType = "application/octet-stream";
+            }
+
+            String filename = safeFilename(filePath.getFileName().toString());
+
+            return new StorageDownloadResult.InlineResult(content, contentType, filename);
+        } catch (IOException e) {
+            throw new FileStorageException("Failed to read local file", e);
+        }
+    }
+
+    /** Strips characters that could enable HTTP header injection via Content-Disposition. */
+    private String safeFilename(String rawName) {
+        if (rawName == null || rawName.isBlank()) {
+            return "download";
+        }
+        return rawName.replaceAll("[\\r\\n\"\\\\]", "_");
     }
 
     @Override

--- a/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapter.java
@@ -8,11 +8,16 @@ import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.List;
+import java.util.Properties;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -31,11 +36,44 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
 
     private static final String DEFAULT_CONTENT_TYPE = "application/octet-stream";
 
+    /**
+     * Suffix of the sidecar files that record the content type validated at upload time. Local disk
+     * has no equivalent of MinIO's per-object metadata, so the value travels in a companion file.
+     * The suffix is reserved: a path ending in it can neither be stored nor read back through this
+     * adapter, so the sidecars are not themselves reachable from the public download endpoint.
+     */
+    private static final String METADATA_SUFFIX = ".meta";
+
+    private static final String CONTENT_TYPE_KEY = "contentType";
+
+    /** Lexical root: absolute and normalized, but symbolic links left unresolved. */
     private final Path storageLocation;
+
+    /**
+     * Same directory with every symbolic link resolved. Containment is checked against this, since
+     * {@link Path#normalize()} is pure string math and would accept a link inside the storage
+     * directory that points outside it. Held separately from {@link #storageLocation} because
+     * callers' relative paths are resolved lexically (no filesystem access) before being checked.
+     */
+    private final Path storageRoot;
 
     public LocalStorageAdapter(@Value("${storage.local.path:./uploads}") String storagePath) {
         this.storageLocation = Paths.get(storagePath).toAbsolutePath().normalize();
         createStorageDirectory();
+        this.storageRoot = resolveStorageRoot();
+    }
+
+    /**
+     * Resolves the real path of the storage root once at startup. The root itself is frequently a
+     * symbolic link (macOS {@code /tmp}, container mounts, JUnit temp dirs), so comparing candidate
+     * real paths against an unresolved root would reject every legitimate file.
+     */
+    private Path resolveStorageRoot() {
+        try {
+            return storageLocation.toRealPath();
+        } catch (IOException e) {
+            throw new FileStorageException("Failed to resolve storage directory", e);
+        }
     }
 
     private void createStorageDirectory() {
@@ -57,10 +95,21 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
                 throw new FileStorageException("Invalid file path - path traversal detected");
             }
 
+            if (isMetadataPath(targetLocation)) {
+                throw new FileStorageException("Invalid file path - reserved metadata suffix");
+            }
+
+            // Checked before createDirectories: if an existing ancestor is a link out of the
+            // root, creating directories through it would materialize them outside the root.
+            if (!isWithinStorageRoot(targetLocation)) {
+                throw new FileStorageException("Invalid file path - resolves outside storage root");
+            }
+
             // Create parent directories if they don't exist
             Files.createDirectories(targetLocation.getParent());
 
             Files.write(targetLocation, file.bytes());
+            writeContentTypeSidecar(targetLocation, file.contentType());
             log.debug("Stored file locally: {}", path);
 
             // Return API path for local storage
@@ -81,11 +130,19 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
         try {
             Path filePath = storageLocation.resolve(path).normalize();
 
-            if (!filePath.startsWith(storageLocation)) {
+            if (!filePath.startsWith(storageLocation) || isMetadataPath(filePath)) {
                 throw new FileValidationException("Invalid file path - path traversal detected");
             }
 
+            if (!isWithinStorageRoot(filePath)) {
+                throw new FileValidationException(
+                        "Invalid file path - resolves outside storage root");
+            }
+
             Files.deleteIfExists(filePath);
+            // Removed together with the file it describes, so a later upload to the same path
+            // cannot inherit the previous file's recorded content type.
+            Files.deleteIfExists(metadataPathFor(filePath));
             log.debug("Deleted local file: {}", path);
         } catch (IOException e) {
             throw new FileStorageException("Failed to delete file", e);
@@ -95,7 +152,10 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
     @Override
     public boolean exists(String path) {
         Path filePath = storageLocation.resolve(path).normalize();
-        return filePath.startsWith(storageLocation) && Files.exists(filePath);
+        return filePath.startsWith(storageLocation)
+                && !isMetadataPath(filePath)
+                && isWithinStorageRoot(filePath)
+                && Files.exists(filePath);
     }
 
     @Override
@@ -149,6 +209,16 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
             throw new FileValidationException("Invalid file path - path traversal detected");
         }
 
+        // Reported as missing rather than rejected: the sidecars are an implementation detail,
+        // and a 404 does not disclose whether one exists.
+        if (isMetadataPath(filePath)) {
+            throw new StoredFileNotFoundException(path);
+        }
+
+        if (!isWithinStorageRoot(filePath)) {
+            throw new FileValidationException("Invalid file path - resolves outside storage root");
+        }
+
         if (!Files.exists(filePath) || !Files.isRegularFile(filePath)) {
             throw new StoredFileNotFoundException(path);
         }
@@ -157,13 +227,57 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
     }
 
     /**
-     * Determines the content type from the filename extension first, falling back to the platform's
-     * probe. Extension mapping is used in preference because {@link Files#probeContentType}
-     * consults host-specific databases (e.g. /etc/mime.types) and returns null on minimal
-     * containers, which would otherwise make the served content type depend on where the app
-     * happens to run.
+     * Reports whether {@code candidate} stays inside the storage root once symbolic links are
+     * resolved. Checked against the deepest ancestor that currently exists, so the answer is
+     * meaningful for a file that has not been written yet while still catching a linked ancestor.
+     *
+     * <p>Fails closed: an unreadable path is treated as outside the root rather than assumed safe.
+     */
+    private boolean isWithinStorageRoot(Path candidate) {
+        Path existing = candidate;
+        while (existing != null && !Files.exists(existing, LinkOption.NOFOLLOW_LINKS)) {
+            existing = existing.getParent();
+        }
+
+        if (existing == null) {
+            return false;
+        }
+
+        try {
+            return existing.toRealPath().startsWith(storageRoot);
+        } catch (IOException e) {
+            log.warn("Failed to resolve real path for containment check: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean isMetadataPath(Path filePath) {
+        Path fileName = filePath.getFileName();
+        return fileName != null && fileName.toString().endsWith(METADATA_SUFFIX);
+    }
+
+    private Path metadataPathFor(Path filePath) {
+        return filePath.resolveSibling(filePath.getFileName().toString() + METADATA_SUFFIX);
+    }
+
+    /**
+     * Returns the content type validated at upload time when a sidecar is present, falling back to
+     * the filename extension for files written to the storage directory by other means (fixtures,
+     * or uploads that predate the sidecars). Extension mapping is preferred over {@link
+     * Files#probeContentType} because probing consults host-specific databases (e.g.
+     * /etc/mime.types) and returns null on minimal containers, which would otherwise make the
+     * served content type depend on where the app happens to run.
+     *
+     * <p>The result is descriptive only. Whether a type may be rendered inline is decided
+     * separately at the HTTP boundary, so neither a stale sidecar nor a hostile filename here can
+     * turn a stored file into active content.
      */
     private String resolveContentType(Path filePath) {
+        String recorded = readContentTypeSidecar(filePath);
+        if (recorded != null && !recorded.isBlank()) {
+            return recorded;
+        }
+
         String fileName = filePath.getFileName().toString();
         return MediaTypeFactory.getMediaType(fileName)
                 .map(MimeType::toString)
@@ -178,6 +292,48 @@ public class LocalStorageAdapter implements IFileStorageAdapter {
                                 return DEFAULT_CONTENT_TYPE;
                             }
                         });
+    }
+
+    private String readContentTypeSidecar(Path filePath) {
+        Path sidecar = metadataPathFor(filePath);
+        if (!Files.isRegularFile(sidecar)) {
+            return null;
+        }
+
+        Properties recorded = new Properties();
+        try (Reader reader = Files.newBufferedReader(sidecar, StandardCharsets.UTF_8)) {
+            recorded.load(reader);
+        } catch (IOException e) {
+            log.warn("Failed to read stored content type for {}: {}", filePath, e.getMessage());
+            return null;
+        }
+        return recorded.getProperty(CONTENT_TYPE_KEY);
+    }
+
+    /**
+     * Records the validated content type alongside the stored file, or clears a stale record when
+     * the upload carries no type, so a replacement never inherits the previous file's type.
+     *
+     * <p>A sidecar failure is logged rather than thrown: the file itself is already written, and
+     * downloads fall back to the extension mapping — which, for uploads that came through {@code
+     * FileStorageService}, is itself derived from the validated content type.
+     */
+    private void writeContentTypeSidecar(Path filePath, String contentType) {
+        Path sidecar = metadataPathFor(filePath);
+        try {
+            if (contentType == null || contentType.isBlank()) {
+                Files.deleteIfExists(sidecar);
+                return;
+            }
+
+            Properties recorded = new Properties();
+            recorded.setProperty(CONTENT_TYPE_KEY, contentType);
+            try (Writer writer = Files.newBufferedWriter(sidecar, StandardCharsets.UTF_8)) {
+                recorded.store(writer, "Content type validated at upload time");
+            }
+        } catch (IOException e) {
+            log.warn("Failed to record content type for {}: {}", filePath, e.getMessage());
+        }
     }
 
     @Override

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ContentDisposition;
@@ -38,14 +39,43 @@ public class FileController extends BaseController {
     private static final int DEFAULT_EXPIRY_MINUTES = 60;
     private static final String FALLBACK_FILE_NAME = "download";
 
+    /**
+     * Content types this endpoint will render in the browser. Anything else is served as an opaque
+     * attachment, because a type the browser executes in a document context (text/html,
+     * image/svg+xml, ...) must never be rendered from this origin: downloads are public, and the
+     * bytes originate from user uploads.
+     *
+     * <p>Listed explicitly rather than read from {@code storage.allowed-content-types} so that
+     * widening what may be uploaded cannot silently widen what a browser will execute.
+     */
+    private static final Set<MediaType> INLINE_SAFE_TYPES =
+            Set.of(
+                    MediaType.IMAGE_JPEG,
+                    MediaType.IMAGE_PNG,
+                    MediaType.IMAGE_GIF,
+                    new MediaType("image", "webp"),
+                    MediaType.APPLICATION_PDF);
+
+    private static final String CONTENT_TYPE_OPTIONS_HEADER = "X-Content-Type-Options";
+    private static final String CONTENT_SECURITY_POLICY_HEADER = "Content-Security-Policy";
+
+    /**
+     * Applied to served file content so that a document rendered from these bytes can load nothing
+     * and submit nowhere. The CSP {@code sandbox} directive is deliberately omitted: it would also
+     * disable the browsers' built-in PDF viewer, and PDFs are served inline.
+     */
+    private static final String FILE_CONTENT_SECURITY_POLICY =
+            "default-src 'none'; base-uri 'none'; form-action 'none'";
+
     @GetMapping("/{*path}")
     @PreAuthorize("permitAll()")
     @Operation(
             summary = "Download file",
             description =
                     "Redirects to a presigned URL when the storage provider supports it (e.g. "
-                            + "MinIO/S3), or streams the file content inline for providers that "
-                            + "don't (e.g. local disk). Public access.")
+                            + "MinIO/S3), or streams the file content for providers that don't "
+                            + "(e.g. local disk) — rendered inline for image and PDF types, and "
+                            + "served as an attachment otherwise. Public access.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
@@ -84,20 +114,38 @@ public class FileController extends BaseController {
     }
 
     private ResponseEntity<byte[]> toInlineResponse(StorageDownloadResult.InlineResult inline) {
-        MediaType mediaType;
-        try {
-            mediaType = MediaType.parseMediaType(inline.contentType());
-        } catch (Exception e) {
-            mediaType = MediaType.APPLICATION_OCTET_STREAM;
-        }
+        MediaType mediaType = resolveServableType(inline.contentType());
+        boolean renderInline = INLINE_SAFE_TYPES.contains(mediaType);
 
         return ResponseEntity.ok()
                 .contentType(mediaType)
                 .contentLength(inline.content().length)
                 .header(
                         HttpHeaders.CONTENT_DISPOSITION,
-                        inlineContentDisposition(inline.filename()))
+                        contentDisposition(inline.filename(), renderInline))
+                // Without nosniff, a mislabeled payload can still be sniffed into an executable
+                // type, which would defeat the downgrade above.
+                .header(CONTENT_TYPE_OPTIONS_HEADER, "nosniff")
+                .header(CONTENT_SECURITY_POLICY_HEADER, FILE_CONTENT_SECURITY_POLICY)
                 .body(inline.content());
+    }
+
+    /**
+     * Parses the stored content type and downgrades anything outside {@link #INLINE_SAFE_TYPES} to
+     * application/octet-stream, so a stored value that is unexpected, stale, or hostile cannot
+     * become the response type. Parameters are dropped because they are not part of the type's
+     * identity and would defeat the comparison.
+     */
+    private MediaType resolveServableType(String storedContentType) {
+        try {
+            MediaType parsed = MediaType.parseMediaType(storedContentType);
+            MediaType bareType = new MediaType(parsed.getType(), parsed.getSubtype());
+            return INLINE_SAFE_TYPES.contains(bareType)
+                    ? bareType
+                    : MediaType.APPLICATION_OCTET_STREAM;
+        } catch (Exception e) {
+            return MediaType.APPLICATION_OCTET_STREAM;
+        }
     }
 
     /**
@@ -107,16 +155,17 @@ public class FileController extends BaseController {
      * passed conditionally because Spring also MIME-encodes the plain {@code filename} parameter
      * whenever a charset is present, which needlessly obscures ordinary ASCII names.
      */
-    private String inlineContentDisposition(String rawFileName) {
+    private String contentDisposition(String rawFileName, boolean renderInline) {
         String safeName = sanitizeForHeader(rawFileName);
         boolean asciiOnly = StandardCharsets.US_ASCII.newEncoder().canEncode(safeName);
 
+        ContentDisposition.Builder builder =
+                renderInline ? ContentDisposition.inline() : ContentDisposition.attachment();
+
         ContentDisposition disposition =
                 asciiOnly
-                        ? ContentDisposition.inline().filename(safeName).build()
-                        : ContentDisposition.inline()
-                                .filename(safeName, StandardCharsets.UTF_8)
-                                .build();
+                        ? builder.filename(safeName).build()
+                        : builder.filename(safeName, StandardCharsets.UTF_8).build();
 
         return disposition.toString();
     }

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -12,9 +12,11 @@ import io.swagger.v3.oas.annotations.media.SchemaProperty;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ContentDisposition;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -34,6 +36,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class FileController extends BaseController {
 
     private static final int DEFAULT_EXPIRY_MINUTES = 60;
+    private static final String FALLBACK_FILE_NAME = "download";
 
     @GetMapping("/{*path}")
     @PreAuthorize("permitAll()")
@@ -93,15 +96,42 @@ public class FileController extends BaseController {
                 .contentLength(inline.content().length)
                 .header(
                         HttpHeaders.CONTENT_DISPOSITION,
-                        "inline; filename=\"" + sanitizeForHeader(inline.filename()) + "\"")
+                        inlineContentDisposition(inline.filename()))
                 .body(inline.content());
     }
 
+    /**
+     * Builds the Content-Disposition header, adding the RFC 5987 {@code filename*} form only when
+     * the name actually needs it. Non-ASCII names (e.g. "özgeçmiş.pdf") would otherwise be mangled
+     * by the ISO-8859-1 encoding the servlet layer applies to raw header strings. The charset is
+     * passed conditionally because Spring also MIME-encodes the plain {@code filename} parameter
+     * whenever a charset is present, which needlessly obscures ordinary ASCII names.
+     */
+    private String inlineContentDisposition(String rawFileName) {
+        String safeName = sanitizeForHeader(rawFileName);
+        boolean asciiOnly = StandardCharsets.US_ASCII.newEncoder().canEncode(safeName);
+
+        ContentDisposition disposition =
+                asciiOnly
+                        ? ContentDisposition.inline().filename(safeName).build()
+                        : ContentDisposition.inline()
+                                .filename(safeName, StandardCharsets.UTF_8)
+                                .build();
+
+        return disposition.toString();
+    }
+
+    /**
+     * Drops path separators and control characters before the name reaches the header builder.
+     * {@link ContentDisposition} handles quoting and encoding, but not header injection or a name
+     * that smuggles in a directory component.
+     */
     private String sanitizeForHeader(String filename) {
         if (filename == null || filename.isBlank()) {
-            return "file";
+            return FALLBACK_FILE_NAME;
         }
-        return filename.replaceAll("[\\r\\n\"\\\\]", "_");
+        String cleaned = filename.replaceAll("[\\p{Cntrl}/\\\\]", "").trim();
+        return cleaned.isEmpty() ? FALLBACK_FILE_NAME : cleaned;
     }
 
     @PostMapping

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -45,54 +45,56 @@ public class FileController extends BaseController {
                             + "don't (e.g. local disk). Public access.")
     @ApiResponses(
             value = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "302",
-                            description = "Redirect to presigned URL"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "File content streamed inline"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "File not found")
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "302",
+                        description = "Redirect to presigned URL"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "File content streamed inline"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "404",
+                        description = "File not found")
             })
     public ResponseEntity<?> downloadFile(
             @Parameter(
-                    description = "File path relative to storage root",
-                    required = true,
-                    example = "profile-pictures/avatar.png")
-            @PathVariable
-            String path) {
+                            description = "File path relative to storage root",
+                            required = true,
+                            example = "profile-pictures/avatar.png")
+                    @PathVariable
+                    String path) {
         ApiResponse<StorageDownloadResult> response = mediator.send(new DownloadFileQuery(path));
         HttpStatus status = resolveHttpStatus(response.getCode());
 
-        if (status.is2xxSuccessful()) {
-            StorageDownloadResult result = response.getData();
-
-            if (result instanceof StorageDownloadResult.RedirectResult redirect) {
-                return ResponseEntity.status(HttpStatus.FOUND)
-                        .header(HttpHeaders.LOCATION, redirect.url())
-                        .build();
-            }
-
-            if (result instanceof StorageDownloadResult.InlineResult inline) {
-                MediaType mediaType;
-                try {
-                    mediaType = MediaType.parseMediaType(inline.contentType());
-                } catch (Exception e) {
-                    mediaType = MediaType.APPLICATION_OCTET_STREAM;
-                }
-
-                return ResponseEntity.ok()
-                        .contentType(mediaType)
-                        .contentLength(inline.content().length)
-                        .header(
-                                HttpHeaders.CONTENT_DISPOSITION,
-                                "inline; filename=\"" + sanitizeForHeader(inline.filename()) + "\"")
-                        .body(inline.content());
-            }
+        if (!status.is2xxSuccessful()) {
+            return ResponseEntity.status(status).body(response);
         }
 
-        return ResponseEntity.status(status).body(response);
+        // Exhaustive over the sealed StorageDownloadResult: a new variant becomes a compile
+        // error here rather than silently falling through to a 200 with a JSON body.
+        return switch (response.getData()) {
+            case StorageDownloadResult.RedirectResult redirect ->
+                    ResponseEntity.status(HttpStatus.FOUND)
+                            .header(HttpHeaders.LOCATION, redirect.url())
+                            .build();
+            case StorageDownloadResult.InlineResult inline -> toInlineResponse(inline);
+        };
+    }
+
+    private ResponseEntity<byte[]> toInlineResponse(StorageDownloadResult.InlineResult inline) {
+        MediaType mediaType;
+        try {
+            mediaType = MediaType.parseMediaType(inline.contentType());
+        } catch (Exception e) {
+            mediaType = MediaType.APPLICATION_OCTET_STREAM;
+        }
+
+        return ResponseEntity.ok()
+                .contentType(mediaType)
+                .contentLength(inline.content().length)
+                .header(
+                        HttpHeaders.CONTENT_DISPOSITION,
+                        "inline; filename=\"" + sanitizeForHeader(inline.filename()) + "\"")
+                .body(inline.content());
     }
 
     private String sanitizeForHeader(String filename) {
@@ -134,18 +136,18 @@ public class FileController extends BaseController {
                                                             contentType = "*/*"))))
     @ApiResponses(
             value = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "File uploaded successfully",
-                            content =
-                            @Content(
-                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                    schema = @Schema(implementation = ApiResponse.class),
-                                    examples =
-                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
-                                            name = "Success Response",
-                                            value =
-                                                    """
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "200",
+                        description = "File uploaded successfully",
+                        content =
+                                @Content(
+                                        mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                        schema = @Schema(implementation = ApiResponse.class),
+                                        examples =
+                                                @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                                        name = "Success Response",
+                                                        value =
+                                                                """
                             {
                                 "code": 0,
                                 "message": "File uploaded successfully",
@@ -156,15 +158,15 @@ public class FileController extends BaseController {
                                 }
                             }
                             """))),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "Invalid file or validation error"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "401",
-                            description = "Unauthorized - authentication required"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "Internal server error")
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "400",
+                        description = "Invalid file or validation error"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "401",
+                        description = "Unauthorized - authentication required"),
+                @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                        responseCode = "500",
+                        description = "Internal server error")
             })
     public ResponseEntity<ApiResponse<Map<String, Object>>> uploadFile(
             @RequestParam("file") MultipartFile file) {

--- a/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
+++ b/src/main/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileController.java
@@ -3,6 +3,7 @@ package com.iyte_yazilim.proje_pazari.presentation.controllers;
 import com.iyte_yazilim.proje_pazari.application.commands.uploadFile.UploadFileCommand;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.queries.downloadFile.DownloadFileQuery;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -39,34 +40,66 @@ public class FileController extends BaseController {
     @Operation(
             summary = "Download file",
             description =
-                    "Redirects to presigned URL for file access. "
-                            + "Supports images, PDFs, and documents. Public access.")
+                    "Redirects to a presigned URL when the storage provider supports it (e.g. "
+                            + "MinIO/S3), or streams the file content inline for providers that "
+                            + "don't (e.g. local disk). Public access.")
     @ApiResponses(
             value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "302",
-                        description = "Redirect to presigned URL"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "404",
-                        description = "File not found")
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "302",
+                            description = "Redirect to presigned URL"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "File content streamed inline"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "404",
+                            description = "File not found")
             })
     public ResponseEntity<?> downloadFile(
             @Parameter(
-                            description = "File path relative to storage root",
-                            required = true,
-                            example = "profile-pictures/avatar.png")
-                    @PathVariable
-                    String path) {
-        ApiResponse<String> response = mediator.send(new DownloadFileQuery(path));
+                    description = "File path relative to storage root",
+                    required = true,
+                    example = "profile-pictures/avatar.png")
+            @PathVariable
+            String path) {
+        ApiResponse<StorageDownloadResult> response = mediator.send(new DownloadFileQuery(path));
         HttpStatus status = resolveHttpStatus(response.getCode());
 
         if (status.is2xxSuccessful()) {
-            return ResponseEntity.status(HttpStatus.FOUND)
-                    .header(HttpHeaders.LOCATION, response.getData())
-                    .build();
+            StorageDownloadResult result = response.getData();
+
+            if (result instanceof StorageDownloadResult.RedirectResult redirect) {
+                return ResponseEntity.status(HttpStatus.FOUND)
+                        .header(HttpHeaders.LOCATION, redirect.url())
+                        .build();
+            }
+
+            if (result instanceof StorageDownloadResult.InlineResult inline) {
+                MediaType mediaType;
+                try {
+                    mediaType = MediaType.parseMediaType(inline.contentType());
+                } catch (Exception e) {
+                    mediaType = MediaType.APPLICATION_OCTET_STREAM;
+                }
+
+                return ResponseEntity.ok()
+                        .contentType(mediaType)
+                        .contentLength(inline.content().length)
+                        .header(
+                                HttpHeaders.CONTENT_DISPOSITION,
+                                "inline; filename=\"" + sanitizeForHeader(inline.filename()) + "\"")
+                        .body(inline.content());
+            }
         }
 
         return ResponseEntity.status(status).body(response);
+    }
+
+    private String sanitizeForHeader(String filename) {
+        if (filename == null || filename.isBlank()) {
+            return "file";
+        }
+        return filename.replaceAll("[\\r\\n\"\\\\]", "_");
     }
 
     @PostMapping
@@ -101,37 +134,37 @@ public class FileController extends BaseController {
                                                             contentType = "*/*"))))
     @ApiResponses(
             value = {
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "200",
-                        description = "File uploaded successfully",
-                        content =
-                                @Content(
-                                        mediaType = MediaType.APPLICATION_JSON_VALUE,
-                                        schema = @Schema(implementation = ApiResponse.class),
-                                        examples =
-                                                @io.swagger.v3.oas.annotations.media.ExampleObject(
-                                                        name = "Success Response",
-                                                        value =
-                                                                """
-                                        {
-                                            "code": 0,
-                                            "message": "File uploaded successfully",
-                                            "data": {
-                                                "filename": "document.pdf",
-                                                "url": "/api/v1/files/document.pdf",
-                                                "size": 1024567
-                                            }
-                                        }
-                                        """))),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "400",
-                        description = "Invalid file or validation error"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "401",
-                        description = "Unauthorized - authentication required"),
-                @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                        responseCode = "500",
-                        description = "Internal server error")
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "File uploaded successfully",
+                            content =
+                            @Content(
+                                    mediaType = MediaType.APPLICATION_JSON_VALUE,
+                                    schema = @Schema(implementation = ApiResponse.class),
+                                    examples =
+                                    @io.swagger.v3.oas.annotations.media.ExampleObject(
+                                            name = "Success Response",
+                                            value =
+                                                    """
+                            {
+                                "code": 0,
+                                "message": "File uploaded successfully",
+                                "data": {
+                                    "filename": "document.pdf",
+                                    "url": "/api/v1/files/document.pdf",
+                                    "size": 1024567
+                                }
+                            }
+                            """))),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "Invalid file or validation error"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "401",
+                            description = "Unauthorized - authentication required"),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "500",
+                            description = "Internal server error")
             })
     public ResponseEntity<ApiResponse<Map<String, Object>>> uploadFile(
             @RequestParam("file") MultipartFile file) {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -27,6 +27,7 @@ validation.field.max={0} alanı en fazla {1} karakter olmalıdır
 validation.file.required=Dosya gereklidir
 validation.file.type.invalid=Yalnızca resim dosyaları yüklenebilir
 validation.file.size.exceeded=Dosya boyutu 5MB'ı aşıyor
+file.not.found=Dosya bulunamadı
 validation.url.invalid=Geçersiz URL formatı
 validation.url.linkedin.invalid=Geçersiz LinkedIn URL formatı
 validation.url.github.invalid=Geçersiz GitHub URL formatı

--- a/src/main/resources/messages_en.properties
+++ b/src/main/resources/messages_en.properties
@@ -27,6 +27,7 @@ validation.field.max={0} field must not exceed {1} characters
 validation.file.required=File is required
 validation.file.type.invalid=Only image files are allowed
 validation.file.size.exceeded=File size exceeds 5MB limit
+file.not.found=File not found
 validation.url.invalid=Invalid URL format
 validation.url.linkedin.invalid=Invalid LinkedIn URL format
 validation.url.github.invalid=Invalid GitHub URL format

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandlerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/queries/downloadFile/DownloadFileHandlerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.ResponseCode;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -38,15 +39,36 @@ class DownloadFileHandlerTest {
     @Test
     @DisplayName("1. Leading slash from {*path} binding is stripped, valid relative path checked")
     void singleLeadingSlash_isStrippedAndPassedThrough() {
+        StorageDownloadResult redirect =
+                new StorageDownloadResult.RedirectResult("https://example.com/signed");
         org.mockito.Mockito.when(fileStorageService.fileExists("profiles/test.jpg"))
                 .thenReturn(true);
-        org.mockito.Mockito.when(fileStorageService.getFileUrl("profiles/test.jpg", 60))
-                .thenReturn("https://example.com/signed");
+        org.mockito.Mockito.when(fileStorageService.getDownloadResult("profiles/test.jpg", 60))
+                .thenReturn(redirect);
 
-        ApiResponse<String> response = handler.handle(new DownloadFileQuery("/profiles/test.jpg"));
+        ApiResponse<StorageDownloadResult> response =
+                handler.handle(new DownloadFileQuery("/profiles/test.jpg"));
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
-        assertThat(response.getData()).isEqualTo("https://example.com/signed");
+        assertThat(response.getData()).isEqualTo(redirect);
+    }
+
+    @Test
+    @DisplayName("1b. Local provider result is carried through as inline content, not a URL")
+    void localProvider_returnsInlineResult() {
+        byte[] bytes = "local-bytes".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        StorageDownloadResult inline =
+                new StorageDownloadResult.InlineResult(bytes, "image/jpeg", "test.jpg");
+        org.mockito.Mockito.when(fileStorageService.fileExists("profiles/test.jpg"))
+                .thenReturn(true);
+        org.mockito.Mockito.when(fileStorageService.getDownloadResult("profiles/test.jpg", 60))
+                .thenReturn(inline);
+
+        ApiResponse<StorageDownloadResult> response =
+                handler.handle(new DownloadFileQuery("/profiles/test.jpg"));
+
+        assertThat(response.getCode()).isEqualTo(ResponseCode.SUCCESS);
+        assertThat(response.getData()).isInstanceOf(StorageDownloadResult.InlineResult.class);
     }
 
     @Test
@@ -56,7 +78,7 @@ class DownloadFileHandlerTest {
         // guard is actually load-bearing: calling handle() directly bypasses
         // StrictHttpFirewall entirely, so this is the non-HTTP-entry-point scenario that guard
         // exists for. Over HTTP this exact payload never reaches the handler (verified locally).
-        ApiResponse<String> response =
+        ApiResponse<StorageDownloadResult> response =
                 handler.handle(new DownloadFileQuery("/profiles/../../etc/passwd"));
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.BAD_REQUEST);
@@ -67,7 +89,8 @@ class DownloadFileHandlerTest {
     @Test
     @DisplayName("3. Double leading slash (extra slash beyond the routing artifact) is rejected")
     void doubleLeadingSlash_isRejected() {
-        ApiResponse<String> response = handler.handle(new DownloadFileQuery("//profiles/test.jpg"));
+        ApiResponse<StorageDownloadResult> response =
+                handler.handle(new DownloadFileQuery("//profiles/test.jpg"));
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.BAD_REQUEST);
         assertThat(response.getMessage()).isEqualTo("Invalid file path");
@@ -79,7 +102,7 @@ class DownloadFileHandlerTest {
     void singleEncodedLeadingSlash_isRejected() {
         // After the mandatory /{*path} leading slash is stripped, decoding "%2Fprofiles/test.jpg"
         // yields "/profiles/test.jpg" — a second, real leading slash — which must be rejected.
-        ApiResponse<String> response =
+        ApiResponse<StorageDownloadResult> response =
                 handler.handle(new DownloadFileQuery("/%2Fprofiles/test.jpg"));
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.BAD_REQUEST);
@@ -90,7 +113,7 @@ class DownloadFileHandlerTest {
     @Test
     @DisplayName("5. Double-URL-encoded traversal (%252e%252e%252f) is fully decoded and rejected")
     void doubleEncodedTraversal_isRejected() {
-        ApiResponse<String> response =
+        ApiResponse<StorageDownloadResult> response =
                 handler.handle(new DownloadFileQuery("/profiles/%252e%252e%252fetc/passwd"));
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.BAD_REQUEST);
@@ -101,7 +124,7 @@ class DownloadFileHandlerTest {
     @Test
     @DisplayName("5b. Nested double-URL-encoded traversal is also rejected")
     void nestedDoubleEncodedTraversal_isRejected() {
-        ApiResponse<String> response =
+        ApiResponse<StorageDownloadResult> response =
                 handler.handle(new DownloadFileQuery("/%252e%252e%252f%252e%252e%252fetc/passwd"));
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.BAD_REQUEST);
@@ -112,7 +135,7 @@ class DownloadFileHandlerTest {
     @Test
     @DisplayName("6. Blank path returns 400 without touching storage")
     void blankPath_isRejected() {
-        ApiResponse<String> response = handler.handle(new DownloadFileQuery("   "));
+        ApiResponse<StorageDownloadResult> response = handler.handle(new DownloadFileQuery("   "));
 
         assertThat(response.getCode()).isEqualTo(ResponseCode.BAD_REQUEST);
         verifyNoInteractions(fileStorageService);

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageServiceTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageServiceTest.java
@@ -2,8 +2,8 @@ package com.iyte_yazilim.proje_pazari.application.services;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageServiceTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageServiceTest.java
@@ -3,6 +3,7 @@ package com.iyte_yazilim.proje_pazari.application.services;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
@@ -10,6 +11,7 @@ import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -415,5 +417,32 @@ class FileStorageServiceTest {
         assertThrows(
                 FileValidationException.class,
                 () -> fileStorageService.storeUserAvatar("../bad", file));
+    }
+
+    @Test
+    @DisplayName("Should delegate download resolution to adapter after path validation")
+    void shouldGetDownloadResult_delegatesToAdapter() {
+        // Given
+        String path = "profiles/photo.jpg";
+        StorageDownloadResult expected =
+                new StorageDownloadResult.RedirectResult(
+                        "https://storage.example.com/presigned/photo.jpg");
+        when(storageAdapter.resolveDownload(path, 60)).thenReturn(expected);
+
+        // When
+        StorageDownloadResult result = fileStorageService.getDownloadResult(path, 60);
+
+        // Then
+        assertEquals(expected, result);
+        verify(storageAdapter).resolveDownload(path, 60);
+    }
+
+    @Test
+    @DisplayName("Should reject traversal path before calling adapter for download resolution")
+    void shouldGetDownloadResult_rejectsInvalidPath() {
+        assertThrows(
+                FileValidationException.class,
+                () -> fileStorageService.getDownloadResult("../etc/passwd", 60));
+        verify(storageAdapter, never()).resolveDownload(anyString(), anyInt());
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageServiceTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/application/services/FileStorageServiceTest.java
@@ -445,4 +445,98 @@ class FileStorageServiceTest {
                 () -> fileStorageService.getDownloadResult("../etc/passwd", 60));
         verify(storageAdapter, never()).resolveDownload(anyString(), anyInt());
     }
+
+    @Test
+    @DisplayName("Avatar extension comes from the validated content type, not the filename")
+    void shouldStoreAvatar_withExtensionFromContentType_whenFilenameDisagrees() {
+        // An allowed content type paired with an active extension: only the declared content
+        // type is validated, so the filename must not decide what lands on disk.
+        MockMultipartFile file =
+                new MockMultipartFile("file", "avatar.html", "image/jpeg", "img".getBytes());
+        String expectedPath = "proje-pazari-avatars/users/user-1/avatar.jpg";
+
+        when(storageAdapter.store(any(), eq(expectedPath))).thenReturn(expectedPath);
+
+        assertEquals(expectedPath, fileStorageService.storeUserAvatar("user-1", file));
+        verify(storageAdapter).store(any(), eq(expectedPath));
+    }
+
+    @Test
+    @DisplayName("Uploaded file is never stored under an active extension")
+    void shouldStoreFile_withExtensionFromContentType_whenFilenameIsActiveContent() {
+        MockMultipartFile file =
+                new MockMultipartFile("file", "payload.svg", "image/png", "img".getBytes());
+        when(storageAdapter.store(any(FileUpload.class), anyString())).thenReturn("stored");
+
+        fileStorageService.storeFile(file, "uploads");
+
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(storageAdapter).store(any(FileUpload.class), pathCaptor.capture());
+        assertTrue(pathCaptor.getValue().endsWith(".png"));
+        assertFalse(pathCaptor.getValue().contains("svg"));
+    }
+
+    @Test
+    @DisplayName("Project document extension comes from the validated content type")
+    void shouldStoreProjectDocument_withExtensionFromContentType_whenFilenameDisagrees() {
+        MockMultipartFile file =
+                new MockMultipartFile("file", "spec.xhtml", "application/pdf", "pdf".getBytes());
+        String expectedPath = "proje-pazari-documents/projects/proj-1/doc-1.pdf";
+
+        when(storageAdapter.store(any(), eq(expectedPath))).thenReturn(expectedPath);
+
+        assertEquals(
+                expectedPath, fileStorageService.storeProjectDocument("proj-1", "doc-1", file));
+    }
+
+    @Test
+    @DisplayName("Allowed type without a canonical extension is stored opaquely, not rejected")
+    void shouldStoreFile_withOpaqueExtension_whenContentTypeHasNoCanonicalExtension() {
+        ReflectionTestUtils.setField(
+                fileStorageService, "allowedContentTypesString", "image/jpeg,text/csv");
+        MockMultipartFile file =
+                new MockMultipartFile("file", "rows.csv", "text/csv", "a,b".getBytes());
+        when(storageAdapter.store(any(FileUpload.class), anyString())).thenReturn("stored");
+
+        fileStorageService.storeFile(file, "uploads");
+
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(storageAdapter).store(any(FileUpload.class), pathCaptor.capture());
+        assertTrue(pathCaptor.getValue().endsWith(".bin"));
+    }
+
+    @Test
+    @DisplayName("Content type parameters do not defeat the extension mapping")
+    void shouldStoreFile_withCanonicalExtension_whenContentTypeCarriesParameters() {
+        ReflectionTestUtils.setField(
+                fileStorageService, "allowedContentTypesString", "image/jpeg;charset=binary");
+        MockMultipartFile file =
+                new MockMultipartFile(
+                        "file", "photo.jpg", "image/jpeg;charset=binary", "img".getBytes());
+        when(storageAdapter.store(any(FileUpload.class), anyString())).thenReturn("stored");
+
+        fileStorageService.storeFile(file, "uploads");
+
+        ArgumentCaptor<String> pathCaptor = ArgumentCaptor.forClass(String.class);
+        verify(storageAdapter).store(any(FileUpload.class), pathCaptor.capture());
+        assertTrue(pathCaptor.getValue().endsWith(".jpg"));
+    }
+
+    /**
+     * The domain type carries the validated content type into the adapter, which is what allows a
+     * local adapter to record it rather than infer it from the stored filename.
+     */
+    @Test
+    @DisplayName("Validated content type is handed to the adapter with the file")
+    void shouldPassValidatedContentType_toAdapter() {
+        MockMultipartFile file =
+                new MockMultipartFile("file", "avatar.html", "image/jpeg", "img".getBytes());
+        when(storageAdapter.store(any(FileUpload.class), anyString())).thenReturn("stored");
+
+        fileStorageService.storeFile(file, "uploads");
+
+        ArgumentCaptor<FileUpload> uploadCaptor = ArgumentCaptor.forClass(FileUpload.class);
+        verify(storageAdapter).store(uploadCaptor.capture(), anyString());
+        assertEquals("image/jpeg", uploadCaptor.getValue().contentType());
+    }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
@@ -4,8 +4,10 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
+import com.iyte_yazilim.proje_pazari.domain.exceptions.StoredFileNotFoundException;
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -149,10 +151,11 @@ class LocalStorageAdapterUnitTest {
         }
 
         @Test
-        @DisplayName("should throw when file not found")
+        @DisplayName("should throw not-found when file is missing")
         void shouldThrowWhenFileNotFound() {
             assertThrows(
-                    FileValidationException.class, () -> adapter.getMetadata("nonexistent.txt"));
+                    StoredFileNotFoundException.class,
+                    () -> adapter.getMetadata("nonexistent.txt"));
         }
 
         @Test
@@ -164,33 +167,77 @@ class LocalStorageAdapterUnitTest {
     }
 
     @Nested
-    @DisplayName("retrieveAsBytes() method")
-    class RetrieveAsBytesTests {
+    @DisplayName("resolveDownload() method")
+    class ResolveDownloadTests {
 
         @Test
-        @DisplayName("should retrieve file content as bytes")
-        void shouldRetrieveFileContent() {
+        @DisplayName("should return inline content rather than a redirect URL")
+        void shouldReturnInlineContent() {
             byte[] content = "hello bytes".getBytes();
             adapter.store(new FileUpload("f.txt", "text/plain", content, content.length), "f.txt");
 
-            byte[] result = adapter.retrieveAsBytes("f.txt");
+            StorageDownloadResult result = adapter.resolveDownload("f.txt", 60);
 
-            assertArrayEquals(content, result);
+            assertInstanceOf(StorageDownloadResult.InlineResult.class, result);
+            StorageDownloadResult.InlineResult inline = (StorageDownloadResult.InlineResult) result;
+            assertArrayEquals(content, inline.content());
+            assertEquals("f.txt", inline.filename());
         }
 
         @Test
-        @DisplayName("should throw when file not found")
+        @DisplayName("should resolve content type from the extension, not the host mime database")
+        void shouldResolveContentTypeFromExtension() {
+            byte[] content = "not really a jpeg".getBytes();
+            adapter.store(
+                    new FileUpload("avatar.jpg", "image/jpeg", content, content.length),
+                    "avatar.jpg");
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("avatar.jpg", 60);
+
+            assertEquals("image/jpeg", inline.contentType());
+        }
+
+        @Test
+        @DisplayName("should fall back to octet-stream for an unknown extension")
+        void shouldFallBackForUnknownExtension() {
+            byte[] content = "opaque".getBytes();
+            adapter.store(
+                    new FileUpload(
+                            "blob.zzzzz", "application/octet-stream", content, content.length),
+                    "blob.zzzzz");
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("blob.zzzzz", 60);
+
+            assertEquals("application/octet-stream", inline.contentType());
+        }
+
+        @Test
+        @DisplayName("should throw not-found (mapping to 404) when file is missing")
         void shouldThrowWhenFileNotFound() {
             assertThrows(
-                    FileValidationException.class,
-                    () -> adapter.retrieveAsBytes("nonexistent.txt"));
+                    StoredFileNotFoundException.class,
+                    () -> adapter.resolveDownload("nonexistent.txt", 60));
         }
 
         @Test
-        @DisplayName("should throw when path traversal detected")
+        @DisplayName("should throw validation error (mapping to 400) when path traversal detected")
         void shouldThrowOnPathTraversal() {
             assertThrows(
-                    FileValidationException.class, () -> adapter.retrieveAsBytes("../outside.txt"));
+                    FileValidationException.class,
+                    () -> adapter.resolveDownload("../outside.txt", 60));
+        }
+
+        @Test
+        @DisplayName("should never return a URL pointing back at the download endpoint")
+        void shouldNotReturnSelfReferentialRedirect() {
+            byte[] content = "bytes".getBytes();
+            adapter.store(new FileUpload("f.txt", "text/plain", content, content.length), "f.txt");
+
+            StorageDownloadResult result = adapter.resolveDownload("f.txt", 60);
+
+            assertFalse(result instanceof StorageDownloadResult.RedirectResult);
         }
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
@@ -1,6 +1,7 @@
 package com.iyte_yazilim.proje_pazari.infrastructure.storage;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileStorageException;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
@@ -8,6 +9,7 @@ import com.iyte_yazilim.proje_pazari.domain.exceptions.StoredFileNotFoundExcepti
 import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
 import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -185,8 +187,8 @@ class LocalStorageAdapterUnitTest {
         }
 
         @Test
-        @DisplayName("should resolve content type from the extension, not the host mime database")
-        void shouldResolveContentTypeFromExtension() {
+        @DisplayName("should return the content type recorded at store time")
+        void shouldReturnRecordedContentType() {
             byte[] content = "not really a jpeg".getBytes();
             adapter.store(
                     new FileUpload("avatar.jpg", "image/jpeg", content, content.length),
@@ -194,6 +196,35 @@ class LocalStorageAdapterUnitTest {
 
             StorageDownloadResult.InlineResult inline =
                     (StorageDownloadResult.InlineResult) adapter.resolveDownload("avatar.jpg", 60);
+
+            assertEquals("image/jpeg", inline.contentType());
+        }
+
+        @Test
+        @DisplayName("recorded content type wins over the stored filename's extension")
+        void shouldPreferRecordedContentTypeOverExtension() {
+            byte[] content = "<script>alert(1)</script>".getBytes();
+            adapter.store(
+                    new FileUpload("payload.html", "image/jpeg", content, content.length),
+                    "payload.html");
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult)
+                            adapter.resolveDownload("payload.html", 60);
+
+            assertEquals("image/jpeg", inline.contentType());
+        }
+
+        @Test
+        @DisplayName(
+                "should fall back to the extension, not the host mime database, without a record")
+        void shouldResolveContentTypeFromExtensionWithoutRecord() throws Exception {
+            // Written directly, so no sidecar exists — the case for fixtures and for files
+            // stored before content types were recorded.
+            Files.write(tempDir.resolve("seeded.jpg"), "bytes".getBytes());
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("seeded.jpg", 60);
 
             assertEquals("image/jpeg", inline.contentType());
         }
@@ -238,6 +269,143 @@ class LocalStorageAdapterUnitTest {
             StorageDownloadResult result = adapter.resolveDownload("f.txt", 60);
 
             assertFalse(result instanceof StorageDownloadResult.RedirectResult);
+        }
+    }
+
+    @Nested
+    @DisplayName("content type metadata sidecars")
+    class MetadataSidecarTests {
+
+        @Test
+        @DisplayName("should not be readable through the adapter")
+        void shouldNotBeReadable() {
+            byte[] content = "bytes".getBytes();
+            adapter.store(
+                    new FileUpload("avatar.jpg", "image/jpeg", content, content.length),
+                    "avatar.jpg");
+            assertTrue(Files.exists(tempDir.resolve("avatar.jpg.meta")));
+
+            assertThrows(
+                    StoredFileNotFoundException.class,
+                    () -> adapter.resolveDownload("avatar.jpg.meta", 60));
+            assertThrows(
+                    StoredFileNotFoundException.class,
+                    () -> adapter.getMetadata("avatar.jpg.meta"));
+            assertFalse(adapter.exists("avatar.jpg.meta"));
+        }
+
+        @Test
+        @DisplayName("should not be writable through the adapter")
+        void shouldNotBeWritable() {
+            byte[] content = "contentType=text/html".getBytes();
+            FileUpload file = new FileUpload("x.meta", "image/jpeg", content, content.length);
+
+            assertThrows(FileStorageException.class, () -> adapter.store(file, "avatar.jpg.meta"));
+        }
+
+        @Test
+        @DisplayName("should be removed together with the file they describe")
+        void shouldBeDeletedWithFile() {
+            byte[] content = "bytes".getBytes();
+            adapter.store(
+                    new FileUpload("avatar.jpg", "image/jpeg", content, content.length),
+                    "avatar.jpg");
+
+            adapter.delete("avatar.jpg");
+
+            assertFalse(Files.exists(tempDir.resolve("avatar.jpg.meta")));
+        }
+
+        @Test
+        @DisplayName("should not leak a previous content type to a replacement upload")
+        void shouldNotLeakContentTypeToReplacement() {
+            byte[] content = "bytes".getBytes();
+            adapter.store(
+                    new FileUpload("avatar.jpg", "image/jpeg", content, content.length),
+                    "avatar.jpg");
+
+            adapter.store(
+                    new FileUpload("avatar.jpg", null, content, content.length), "avatar.jpg");
+
+            assertFalse(Files.exists(tempDir.resolve("avatar.jpg.meta")));
+        }
+    }
+
+    @Nested
+    @DisplayName("symbolic link containment")
+    class SymlinkContainmentTests {
+
+        private Path outsideFile;
+
+        @BeforeEach
+        void createOutsideTarget(@TempDir Path outsideDir) throws Exception {
+            outsideFile = outsideDir.resolve("secret.txt");
+            Files.write(outsideFile, "host secret".getBytes());
+        }
+
+        private void linkOrSkip(Path link, Path target) {
+            try {
+                Files.createSymbolicLink(link, target);
+            } catch (IOException | UnsupportedOperationException e) {
+                assumeTrue(false, "symbolic links unsupported here: " + e.getMessage());
+            }
+        }
+
+        @Test
+        @DisplayName("should reject reading through a link that points outside the root")
+        void shouldRejectLinkedFile() {
+            linkOrSkip(tempDir.resolve("public-link"), outsideFile);
+
+            assertThrows(
+                    FileValidationException.class,
+                    () -> adapter.resolveDownload("public-link", 60));
+            assertThrows(FileValidationException.class, () -> adapter.getMetadata("public-link"));
+            assertFalse(adapter.exists("public-link"));
+        }
+
+        @Test
+        @DisplayName("should reject reading through a linked directory")
+        void shouldRejectLinkedDirectory() {
+            linkOrSkip(tempDir.resolve("linked-dir"), outsideFile.getParent());
+
+            assertThrows(
+                    FileValidationException.class,
+                    () -> adapter.resolveDownload("linked-dir/secret.txt", 60));
+            assertFalse(adapter.exists("linked-dir/secret.txt"));
+        }
+
+        @Test
+        @DisplayName("should reject writing through a linked directory")
+        void shouldRejectStoreThroughLinkedDirectory() {
+            linkOrSkip(tempDir.resolve("linked-dir"), outsideFile.getParent());
+            byte[] content = "planted".getBytes();
+            FileUpload file = new FileUpload("x.jpg", "image/jpeg", content, content.length);
+
+            assertThrows(FileStorageException.class, () -> adapter.store(file, "linked-dir/x.jpg"));
+            assertFalse(Files.exists(outsideFile.getParent().resolve("x.jpg")));
+        }
+
+        @Test
+        @DisplayName("should reject deleting through a link that points outside the root")
+        void shouldRejectDeleteThroughLink() {
+            linkOrSkip(tempDir.resolve("public-link"), outsideFile);
+
+            assertThrows(FileValidationException.class, () -> adapter.delete("public-link"));
+            assertTrue(Files.exists(outsideFile));
+        }
+
+        @Test
+        @DisplayName("should still serve a link that stays inside the root")
+        void shouldAllowLinkInsideRoot() throws Exception {
+            byte[] content = "inside bytes".getBytes();
+            adapter.store(
+                    new FileUpload("real.jpg", "image/jpeg", content, content.length), "real.jpg");
+            linkOrSkip(tempDir.resolve("alias.jpg"), tempDir.resolve("real.jpg"));
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("alias.jpg", 60);
+
+            assertArrayEquals(content, inline.content());
         }
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
@@ -11,7 +11,9 @@ import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
+import java.util.Arrays;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -438,17 +440,195 @@ class LocalStorageAdapterUnitTest {
         }
 
         @Test
-        @DisplayName("should still serve a link that stays inside the root")
-        void shouldAllowLinkInsideRoot() throws Exception {
+        @DisplayName("should reject a link even when it stays inside the root")
+        void shouldRejectLinkInsideRoot() {
             byte[] content = "inside bytes".getBytes();
             adapter.store(
                     new FileUpload("real.jpg", "image/jpeg", content, content.length), "real.jpg");
             linkOrSkip(tempDir.resolve("alias.jpg"), tempDir.resolve("real.jpg"));
 
-            StorageDownloadResult.InlineResult inline =
-                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("alias.jpg", 60);
+            // One rule for the whole tree: nothing stored locally is written by anything but this
+            // adapter, so a link is a plant regardless of where it points.
+            assertThrows(
+                    FileValidationException.class, () -> adapter.resolveDownload("alias.jpg", 60));
+            assertFalse(adapter.exists("alias.jpg"));
+        }
 
-            assertArrayEquals(content, inline.content());
+        @Test
+        @DisplayName("documents that hard links are outside the containment guarantee")
+        void hardLinkIsServed_documentedTrustBoundary() throws Exception {
+            try {
+                Files.createLink(tempDir.resolve("public.jpg"), outsideFile);
+            } catch (IOException | UnsupportedOperationException e) {
+                assumeTrue(false, "hard links unsupported here: " + e.getMessage());
+            }
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("public.jpg", 60);
+
+            // A hard link is an ordinary directory entry: no no-follow open or real-path check can
+            // tell it from the file it names. Asserted so the documented boundary in
+            // ContainedFileTree stays visible rather than drifting into an assumed guarantee.
+            assertArrayEquals("host secret".getBytes(), inline.content());
+        }
+    }
+
+    @Nested
+    @DisplayName("entries swapped during an operation")
+    class ConcurrentEntrySwapTests {
+
+        private static final int ATTEMPTS = 300;
+
+        private Path outsideFile;
+
+        @BeforeEach
+        void createOutsideTarget(@TempDir Path outsideDir) throws Exception {
+            outsideFile = outsideDir.resolve("secret.txt");
+            Files.write(outsideFile, "host secret".getBytes());
+        }
+
+        private void assumeSymlinksSupported() {
+            Path probe = tempDir.resolve("probe-link");
+            try {
+                Files.createSymbolicLink(probe, outsideFile);
+                Files.delete(probe);
+            } catch (IOException | UnsupportedOperationException e) {
+                assumeTrue(false, "symbolic links unsupported here: " + e.getMessage());
+            }
+        }
+
+        @Test
+        @DisplayName("should not write through a link planted after the target is checked")
+        void shouldNotWriteThroughSwappedTarget() throws Exception {
+            assumeSymlinksSupported();
+            Path target = tempDir.resolve("payload.jpg");
+            byte[] content = "planted upload".getBytes();
+            FileUpload upload =
+                    new FileUpload("payload.jpg", "image/jpeg", content, content.length);
+
+            Thread swapper = startSwapper(() -> toggleLink(target, outsideFile));
+            try {
+                for (int i = 0; i < ATTEMPTS; i++) {
+                    try {
+                        adapter.store(upload, "payload.jpg");
+                    } catch (FileStorageException e) {
+                        // Expected whenever the link is in place when the write is attempted.
+                    }
+                }
+            } finally {
+                stop(swapper);
+            }
+
+            assertArrayEquals("host secret".getBytes(), Files.readAllBytes(outsideFile));
+        }
+
+        @Test
+        @DisplayName("should not write through a directory swapped after the target is checked")
+        void shouldNotWriteThroughSwappedDirectory() throws Exception {
+            assumeSymlinksSupported();
+            Path directory = tempDir.resolve("profiles");
+            Path outsideDir = outsideFile.getParent();
+            byte[] content = "planted upload".getBytes();
+            FileUpload upload =
+                    new FileUpload("payload.jpg", "image/jpeg", content, content.length);
+
+            Thread swapper = startSwapper(() -> toggleDirectoryLink(directory, outsideDir));
+            try {
+                for (int i = 0; i < ATTEMPTS; i++) {
+                    try {
+                        adapter.store(upload, "profiles/payload.jpg");
+                    } catch (FileStorageException e) {
+                        // Expected whenever the link is in place when the write is attempted.
+                    }
+                }
+            } finally {
+                stop(swapper);
+            }
+
+            assertFalse(Files.exists(outsideDir.resolve("payload.jpg"), LinkOption.NOFOLLOW_LINKS));
+            assertArrayEquals("host secret".getBytes(), Files.readAllBytes(outsideFile));
+        }
+
+        @Test
+        @DisplayName("should not read through a link planted after the target is checked")
+        void shouldNotReadThroughSwappedTarget() throws Exception {
+            assumeSymlinksSupported();
+            Path target = tempDir.resolve("payload.jpg");
+            byte[] content = "stored bytes".getBytes();
+
+            Thread swapper = startSwapper(() -> toggleFileOrLink(target, outsideFile, content));
+            try {
+                for (int i = 0; i < ATTEMPTS; i++) {
+                    try {
+                        StorageDownloadResult.InlineResult inline =
+                                (StorageDownloadResult.InlineResult)
+                                        adapter.resolveDownload("payload.jpg", 60);
+                        // A partial read of the file being rewritten is fine; the external
+                        // target's bytes must never come back.
+                        assertFalse(Arrays.equals("host secret".getBytes(), inline.content()));
+                    } catch (FileValidationException | StoredFileNotFoundException e) {
+                        // Expected whenever the link or the gap is what the read finds.
+                    }
+                }
+            } finally {
+                stop(swapper);
+            }
+        }
+
+        private Thread startSwapper(Runnable swap) {
+            Thread thread =
+                    new Thread(
+                            () -> {
+                                while (!Thread.currentThread().isInterrupted()) {
+                                    swap.run();
+                                }
+                            });
+            thread.setDaemon(true);
+            thread.start();
+            return thread;
+        }
+
+        private void stop(Thread swapper) throws Exception {
+            swapper.interrupt();
+            swapper.join(5_000);
+        }
+
+        private void toggleLink(Path link, Path target) {
+            try {
+                Files.deleteIfExists(link);
+                Files.createSymbolicLink(link, target);
+                Files.deleteIfExists(link);
+            } catch (IOException e) {
+                // The adapter is racing the same entry; losing a step is the point.
+            }
+        }
+
+        private void toggleFileOrLink(Path entry, Path target, byte[] content) {
+            try {
+                Files.deleteIfExists(entry);
+                Files.write(entry, content);
+                Files.deleteIfExists(entry);
+                Files.createSymbolicLink(entry, target);
+            } catch (IOException e) {
+                // The adapter is racing the same entry; losing a step is the point.
+            }
+        }
+
+        private void toggleDirectoryLink(Path entry, Path target) {
+            try {
+                if (Files.isDirectory(entry, LinkOption.NOFOLLOW_LINKS)) {
+                    try (var children = Files.list(entry)) {
+                        for (Path child : children.toList()) {
+                            Files.deleteIfExists(child);
+                        }
+                    }
+                }
+                Files.deleteIfExists(entry);
+                Files.createSymbolicLink(entry, target);
+                Files.deleteIfExists(entry);
+            } catch (IOException e) {
+                // The adapter is racing the same entry; losing a step is the point.
+            }
         }
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/LocalStorageAdapterUnitTest.java
@@ -395,6 +395,49 @@ class LocalStorageAdapterUnitTest {
         }
 
         @Test
+        @DisplayName("should not write a content type sidecar through a planted link")
+        void shouldRejectSidecarWriteThroughLink() throws Exception {
+            linkOrSkip(tempDir.resolve("avatar.jpg.meta"), outsideFile);
+            byte[] content = "bytes".getBytes();
+
+            adapter.store(
+                    new FileUpload("avatar.jpg", "image/jpeg", content, content.length),
+                    "avatar.jpg");
+
+            assertArrayEquals("host secret".getBytes(), Files.readAllBytes(outsideFile));
+            assertArrayEquals(content, Files.readAllBytes(tempDir.resolve("avatar.jpg")));
+        }
+
+        @Test
+        @DisplayName("should not read a content type sidecar through a planted link")
+        void shouldRejectSidecarReadThroughLink() throws Exception {
+            Files.write(outsideFile, "contentType=text/html".getBytes());
+            byte[] content = "bytes".getBytes();
+            Files.write(tempDir.resolve("avatar.jpg"), content);
+            linkOrSkip(tempDir.resolve("avatar.jpg.meta"), outsideFile);
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("avatar.jpg", 60);
+
+            assertEquals("image/jpeg", inline.contentType());
+            assertEquals("image/jpeg", adapter.getMetadata("avatar.jpg").contentType());
+        }
+
+        @Test
+        @DisplayName("should not read a content type sidecar linked inside the root")
+        void shouldRejectSidecarReadThroughInRootLink() throws Exception {
+            byte[] content = "bytes".getBytes();
+            Files.write(tempDir.resolve("avatar.jpg"), content);
+            Files.write(tempDir.resolve("planted"), "contentType=text/html".getBytes());
+            linkOrSkip(tempDir.resolve("avatar.jpg.meta"), tempDir.resolve("planted"));
+
+            StorageDownloadResult.InlineResult inline =
+                    (StorageDownloadResult.InlineResult) adapter.resolveDownload("avatar.jpg", 60);
+
+            assertEquals("image/jpeg", inline.contentType());
+        }
+
+        @Test
         @DisplayName("should still serve a link that stays inside the root")
         void shouldAllowLinkInsideRoot() throws Exception {
             byte[] content = "inside bytes".getBytes();

--- a/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/RemoteStorageAdapterRedirectTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/infrastructure/storage/RemoteStorageAdapterRedirectTest.java
@@ -1,0 +1,93 @@
+package com.iyte_yazilim.proje_pazari.infrastructure.storage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
+import com.iyte_yazilim.proje_pazari.domain.models.FileMetadata;
+import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression coverage for the redirect half of the local-download fix: adapters that CAN hand out a
+ * presigned URL (MinIO/S3) must keep redirecting, via {@link IFileStorageAdapter}'s default {@code
+ * resolveDownload}.
+ *
+ * <p>This uses a hand-written fake rather than a Mockito mock on purpose: Mockito does not execute
+ * interface default methods, so a mock-based test would stub the very behavior under test and prove
+ * nothing.
+ */
+class RemoteStorageAdapterRedirectTest {
+
+    private static final String API_ROUTE_PREFIX = "/api/v1/files/";
+
+    /** Minimal stand-in for a remote, presigned-URL-capable backend. */
+    private static final class FakeRemoteStorageAdapter implements IFileStorageAdapter {
+
+        private String requestedPath;
+        private int requestedExpiryMinutes;
+
+        @Override
+        public String store(FileUpload file, String path) {
+            throw new UnsupportedOperationException("not needed for this test");
+        }
+
+        @Override
+        public String generatePresignedUrl(String path, int expirationMinutes) {
+            this.requestedPath = path;
+            this.requestedExpiryMinutes = expirationMinutes;
+            return "https://minio.example.com/bucket/" + path + "?signed=true";
+        }
+
+        @Override
+        public void delete(String path) {
+            throw new UnsupportedOperationException("not needed for this test");
+        }
+
+        @Override
+        public boolean exists(String path) {
+            return true;
+        }
+
+        @Override
+        public FileMetadata getMetadata(String path) {
+            throw new UnsupportedOperationException("not needed for this test");
+        }
+    }
+
+    @Test
+    @DisplayName("Default resolveDownload wraps the presigned URL in a RedirectResult")
+    void defaultResolveDownload_returnsRedirectResult() {
+        FakeRemoteStorageAdapter adapter = new FakeRemoteStorageAdapter();
+
+        StorageDownloadResult result = adapter.resolveDownload("profiles/test.jpg", 60);
+
+        assertThat(result).isInstanceOf(StorageDownloadResult.RedirectResult.class);
+        assertThat(((StorageDownloadResult.RedirectResult) result).url())
+                .isEqualTo("https://minio.example.com/bucket/profiles/test.jpg?signed=true");
+        assertThat(adapter.requestedPath).isEqualTo("profiles/test.jpg");
+        assertThat(adapter.requestedExpiryMinutes).isEqualTo(60);
+    }
+
+    @Test
+    @DisplayName("Remote redirect target never points back at this API's own download route")
+    void defaultResolveDownload_doesNotRedirectToOwnApiRoute() {
+        FakeRemoteStorageAdapter adapter = new FakeRemoteStorageAdapter();
+
+        StorageDownloadResult result = adapter.resolveDownload("profiles/test.jpg", 60);
+        String url = ((StorageDownloadResult.RedirectResult) result).url();
+
+        // This is the exact failure mode of the bug: a Location header that resolves back to
+        // /api/v1/files/** would make the client loop on the same endpoint forever.
+        assertThat(url).doesNotStartWith(API_ROUTE_PREFIX);
+        assertThat(java.net.URI.create(url).getPath()).doesNotStartWith(API_ROUTE_PREFIX);
+    }
+
+    @Test
+    @DisplayName("MinioStorageAdapter inherits the redirect behavior rather than overriding it")
+    void minioAdapter_doesNotOverrideResolveDownload() throws Exception {
+        assertThat(MinioStorageAdapter.class.getDeclaredMethods())
+                .noneMatch(method -> method.getName().equals("resolveDownload"));
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/DownloadFilePathNormalizationIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/DownloadFilePathNormalizationIntegrationTest.java
@@ -12,6 +12,7 @@ import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
 import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -45,9 +46,11 @@ class DownloadFilePathNormalizationIntegrationTest extends IntegrationTestBase {
         void normalPath_existingObject_returns302() throws Exception {
             String presignedUrl = "https://minio.example.com/bucket/profiles/test.jpg?signed=true";
             when(fileStorageAdapter.exists(eq("profiles/test.jpg"))).thenReturn(true);
-            when(fileStorageAdapter.generatePresignedUrl(
-                            eq("profiles/test.jpg"), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            // Mockito never runs interface default methods, so resolveDownload() must be stubbed
+            // explicitly here — the real default wrapping is covered by
+            // RemoteStorageAdapterRedirectTest.
+            when(fileStorageAdapter.resolveDownload(eq("profiles/test.jpg"), any(Integer.class)))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(get(FILES_URL + "/profiles/test.jpg"))
                     .andExpect(status().isFound())
@@ -96,9 +99,8 @@ class DownloadFilePathNormalizationIntegrationTest extends IntegrationTestBase {
             String presignedUrl =
                     "https://minio.example.com/bucket/projects/p1/doc.pdf?signed=true";
             when(fileStorageAdapter.exists(eq("projects/p1/doc.pdf"))).thenReturn(true);
-            when(fileStorageAdapter.generatePresignedUrl(
-                            eq("projects/p1/doc.pdf"), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            when(fileStorageAdapter.resolveDownload(eq("projects/p1/doc.pdf"), any(Integer.class)))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(get(FILES_URL + "/projects/p1/doc.pdf"))
                     .andExpect(status().isFound())

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerIntegrationTest.java
@@ -1,8 +1,8 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -11,10 +11,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import com.iyte_yazilim.proje_pazari.presentation.security.JwtUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -150,8 +150,8 @@ class FileControllerIntegrationTest extends IntegrationTestBase {
                     .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
                     .andExpect(
                             header().string(
-                                    HttpHeaders.CONTENT_DISPOSITION,
-                                    "inline; filename=\"avatar.jpg\""));
+                                            HttpHeaders.CONTENT_DISPOSITION,
+                                            "inline; filename=\"avatar.jpg\""));
         }
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerIntegrationTest.java
@@ -2,6 +2,7 @@ package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -10,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
 import com.iyte_yazilim.proje_pazari.application.services.FileStorageService;
 import com.iyte_yazilim.proje_pazari.domain.exceptions.FileValidationException;
@@ -54,8 +56,8 @@ class FileControllerIntegrationTest extends IntegrationTestBase {
             String token = createVerifiedUserAndGetToken();
             String presignedUrl = "https://minio.example.com/bucket/profiles/test.jpg?signed=true";
             when(fileStorageService.fileExists(anyString())).thenReturn(true);
-            when(fileStorageService.getFileUrl(anyString(), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            when(fileStorageService.getDownloadResult(anyString(), anyInt()))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(
                             get(FILES_URL + "/profiles/test.jpg")
@@ -103,8 +105,8 @@ class FileControllerIntegrationTest extends IntegrationTestBase {
             String token = createVerifiedUserAndGetToken();
             String presignedUrl = "https://minio.example.com/bucket/docs/report.pdf?signed=true";
             when(fileStorageService.fileExists(anyString())).thenReturn(true);
-            when(fileStorageService.getFileUrl(anyString(), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            when(fileStorageService.getDownloadResult(anyString(), anyInt()))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(
                             get(FILES_URL + "/docs/report.pdf")
@@ -120,14 +122,36 @@ class FileControllerIntegrationTest extends IntegrationTestBase {
             String presignedUrl =
                     "https://minio.example.com/bucket/profiles/avatar.png?signed=true";
             when(fileStorageService.fileExists(anyString())).thenReturn(true);
-            when(fileStorageService.getFileUrl(anyString(), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            when(fileStorageService.getDownloadResult(anyString(), anyInt()))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(
                             get(FILES_URL + "/profiles/avatar.png")
                                     .header("Authorization", "Bearer " + token))
                     .andExpect(status().isFound())
                     .andExpect(header().string(HttpHeaders.LOCATION, presignedUrl));
+        }
+
+        @Test
+        @DisplayName("7. Download existing local file returns 200 with inline content")
+        void downloadFile_localProvider_returnsInlineContent() throws Exception {
+            String token = createVerifiedUserAndGetToken();
+            byte[] content = "fake-jpeg-bytes".getBytes();
+            when(fileStorageService.fileExists(anyString())).thenReturn(true);
+            when(fileStorageService.getDownloadResult(anyString(), anyInt()))
+                    .thenReturn(
+                            new StorageDownloadResult.InlineResult(
+                                    content, "image/jpeg", "avatar.jpg"));
+
+            mockMvc.perform(
+                            get(FILES_URL + "/profiles/avatar.jpg")
+                                    .header("Authorization", "Bearer " + token))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
+                    .andExpect(
+                            header().string(
+                                    HttpHeaders.CONTENT_DISPOSITION,
+                                    "inline; filename=\"avatar.jpg\""));
         }
     }
 
@@ -143,8 +167,8 @@ class FileControllerIntegrationTest extends IntegrationTestBase {
             String token = createVerifiedUserAndGetToken();
             String presignedUrl = "https://minio.example.com/bucket/profiles/ulid123.jpg?s=true";
             when(fileStorageService.fileExists(anyString())).thenReturn(true);
-            when(fileStorageService.getFileUrl(anyString(), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            when(fileStorageService.getDownloadResult(anyString(), anyInt()))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(
                             get(FILES_URL + "/profiles/ulid123.jpg")
@@ -158,8 +182,8 @@ class FileControllerIntegrationTest extends IntegrationTestBase {
             String token = createVerifiedUserAndGetToken();
             String presignedUrl = "https://minio.example.com/bucket/projects/proj1/doc.pdf?s=true";
             when(fileStorageService.fileExists(anyString())).thenReturn(true);
-            when(fileStorageService.getFileUrl(anyString(), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            when(fileStorageService.getDownloadResult(anyString(), anyInt()))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(
                             get(FILES_URL + "/projects/proj1/doc.pdf")
@@ -174,8 +198,8 @@ class FileControllerIntegrationTest extends IntegrationTestBase {
             String presignedUrl =
                     "https://minio.example.com/bucket/projects/user1/proj2/att.pdf?s=true";
             when(fileStorageService.fileExists(anyString())).thenReturn(true);
-            when(fileStorageService.getFileUrl(anyString(), any(Integer.class)))
-                    .thenReturn(presignedUrl);
+            when(fileStorageService.getDownloadResult(anyString(), anyInt()))
+                    .thenReturn(new StorageDownloadResult.RedirectResult(presignedUrl));
 
             mockMvc.perform(
                             get(FILES_URL + "/projects/user1/proj2/att.pdf")

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerTest.java
@@ -13,6 +13,7 @@ import com.iyte_yazilim.proje_pazari.application.common.ApiResponse;
 import com.iyte_yazilim.proje_pazari.application.common.IMediator;
 import com.iyte_yazilim.proje_pazari.application.queries.downloadFile.DownloadFileQuery;
 import com.iyte_yazilim.proje_pazari.application.services.MessageService;
+import com.iyte_yazilim.proje_pazari.domain.models.StorageDownloadResult;
 import com.iyte_yazilim.proje_pazari.infrastructure.persistence.UserRepository;
 import com.iyte_yazilim.proje_pazari.presentation.mappers.IRequestMapper;
 import com.iyte_yazilim.proje_pazari.presentation.security.JwtUtil;
@@ -104,7 +105,9 @@ class FileControllerTest {
                     "https://minio.example.com/bucket/profiles/ulid123.jpg?signed=true";
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
-                            ApiResponse.success(presignedUrl, "File URL generated successfully"));
+                            ApiResponse.success(
+                                    new StorageDownloadResult.RedirectResult(presignedUrl),
+                                    "File URL generated successfully"));
 
             mockMvc.perform(get("/api/v1/files/profiles/ulid123.jpg"))
                     .andExpect(status().isFound())
@@ -138,7 +141,9 @@ class FileControllerTest {
             String presignedUrl = "https://minio.example.com/bucket/profiles/photo.png?signed=true";
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
-                            ApiResponse.success(presignedUrl, "File URL generated successfully"));
+                            ApiResponse.success(
+                                    new StorageDownloadResult.RedirectResult(presignedUrl),
+                                    "File URL generated successfully"));
 
             // No Authorization header — endpoint is permitAll
             mockMvc.perform(get("/api/v1/files/profiles/photo.png"))
@@ -152,7 +157,9 @@ class FileControllerTest {
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
                             ApiResponse.success(
-                                    "https://example.com/url", "File URL generated successfully"));
+                                    new StorageDownloadResult.RedirectResult(
+                                            "https://example.com/url"),
+                                    "File URL generated successfully"));
 
             mockMvc.perform(get("/api/v1/files/projects/user123/document.pdf"))
                     .andExpect(status().isFound());
@@ -169,7 +176,9 @@ class FileControllerTest {
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
                             ApiResponse.success(
-                                    "https://example.com/url", "File URL generated successfully"));
+                                    new StorageDownloadResult.RedirectResult(
+                                            "https://example.com/url"),
+                                    "File URL generated successfully"));
 
             mockMvc.perform(get("/api/v1/files/profiles/file%20name.jpg"))
                     .andExpect(status().isFound());
@@ -183,7 +192,9 @@ class FileControllerTest {
             String presignedUrl = "https://minio.example.com/bucket/docs/report.pdf?signed=true";
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
-                            ApiResponse.success(presignedUrl, "File URL generated successfully"));
+                            ApiResponse.success(
+                                    new StorageDownloadResult.RedirectResult(presignedUrl),
+                                    "File URL generated successfully"));
 
             mockMvc.perform(get("/api/v1/files/docs/report.pdf"))
                     .andExpect(status().isFound())
@@ -197,11 +208,33 @@ class FileControllerTest {
                     "https://minio.example.com/bucket/profiles/avatar.png?signed=true";
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
-                            ApiResponse.success(presignedUrl, "File URL generated successfully"));
+                            ApiResponse.success(
+                                    new StorageDownloadResult.RedirectResult(presignedUrl),
+                                    "File URL generated successfully"));
 
             mockMvc.perform(get("/api/v1/files/profiles/avatar.png"))
                     .andExpect(status().isFound())
                     .andExpect(header().string(HttpHeaders.LOCATION, presignedUrl));
+        }
+
+        @Test
+        @DisplayName("Should return inline content with 200 when adapter resolves an InlineResult")
+        void shouldReturnInlineContent_whenAdapterResolvesInlineResult() throws Exception {
+            byte[] content = "fake-jpeg-bytes".getBytes();
+            when(mediator.send(any(DownloadFileQuery.class)))
+                    .thenReturn(
+                            ApiResponse.success(
+                                    new StorageDownloadResult.InlineResult(
+                                            content, "image/jpeg", "avatar.jpg"),
+                                    "File resolved successfully"));
+
+            mockMvc.perform(get("/api/v1/files/profiles/avatar.jpg"))
+                    .andExpect(status().isOk())
+                    .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
+                    .andExpect(
+                            header().string(
+                                    HttpHeaders.CONTENT_DISPOSITION,
+                                    "inline; filename=\"avatar.jpg\""));
         }
     }
 
@@ -215,7 +248,9 @@ class FileControllerTest {
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
                             ApiResponse.success(
-                                    "https://example.com/url", "File URL generated successfully"));
+                                    new StorageDownloadResult.RedirectResult(
+                                            "https://example.com/url"),
+                                    "File URL generated successfully"));
 
             mockMvc.perform(get("/api/v1/files/profiles/user123-ulid.jpg"))
                     .andExpect(status().isFound());
@@ -232,7 +267,9 @@ class FileControllerTest {
             when(mediator.send(any(DownloadFileQuery.class)))
                     .thenReturn(
                             ApiResponse.success(
-                                    "https://example.com/url", "File URL generated successfully"));
+                                    new StorageDownloadResult.RedirectResult(
+                                            "https://example.com/url"),
+                                    "File URL generated successfully"));
 
             mockMvc.perform(get("/api/v1/files/projects/proj-ulid/attachment.pdf"))
                     .andExpect(status().isFound());

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/FileControllerTest.java
@@ -233,8 +233,8 @@ class FileControllerTest {
                     .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
                     .andExpect(
                             header().string(
-                                    HttpHeaders.CONTENT_DISPOSITION,
-                                    "inline; filename=\"avatar.jpg\""));
+                                            HttpHeaders.CONTENT_DISPOSITION,
+                                            "inline; filename=\"avatar.jpg\""));
         }
     }
 

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
@@ -67,6 +67,31 @@ class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    @DisplayName("Non-ASCII filename is RFC 5987 encoded instead of mangled")
+    void downloadFile_localProvider_nonAsciiFilename_isEncoded() throws Exception {
+        Files.write(
+                tempStorageDir.resolve("profiles").resolve("özgeçmiş.pdf"),
+                "cv-bytes".getBytes(StandardCharsets.UTF_8));
+
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+
+        mockMvc.perform(
+                        get(FILES_URL + "/profiles/özgeçmiş.pdf")
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(
+                        header().string(
+                                        HttpHeaders.CONTENT_DISPOSITION,
+                                        org.hamcrest.Matchers.containsString("filename*=UTF-8''")))
+                .andExpect(
+                        header().string(
+                                        HttpHeaders.CONTENT_DISPOSITION,
+                                        org.hamcrest.Matchers.containsString("%C3%B6zge")));
+    }
+
+    @Test
     @DisplayName("Download missing local file returns 404")
     void downloadFile_localProvider_missingFile_returns404() throws Exception {
         String token =

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
@@ -1,0 +1,94 @@
+package com.iyte_yazilim.proje_pazari.presentation.controllers;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+/**
+ * Verifies GET /api/v1/files/{path} against a real LocalStorageAdapter (storage.provider=local),
+ * with no mocked FileStorageService. Regression coverage for the infinite-redirect bug: local
+ * downloads must return 200 with inline content, never a 302 pointing back at the same API path.
+ */
+class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
+
+    private static final String FILES_URL = "/api/v1/files";
+    private static final String VALID_EMAIL = "localfiletest@std.iyte.edu.tr";
+    private static final String VALID_PASSWORD = "SecurePass123!";
+    private static final String VALID_FIRST_NAME = "Local";
+    private static final String VALID_LAST_NAME = "Tester";
+
+    @TempDir static Path tempStorageDir;
+
+    @DynamicPropertySource
+    static void overrideStorageProperties(DynamicPropertyRegistry registry) {
+        registry.add("storage.provider", () -> "local");
+        registry.add("storage.local.path", () -> tempStorageDir.toString());
+    }
+
+    @BeforeEach
+    void seedFile() throws Exception {
+        Path profilesDir = tempStorageDir.resolve("profiles");
+        Files.createDirectories(profilesDir);
+        Files.write(
+                profilesDir.resolve("avatar.jpg"),
+                "fake-jpeg-bytes".getBytes(StandardCharsets.UTF_8));
+    }
+
+    @Test
+    @DisplayName("Download existing local file returns 200 with inline content, not a redirect")
+    void downloadFile_localProvider_returnsInlineContent() throws Exception {
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+
+        mockMvc.perform(
+                        get(FILES_URL + "/profiles/avatar.jpg")
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(content().bytes("fake-jpeg-bytes".getBytes(StandardCharsets.UTF_8)))
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
+                .andExpect(
+                        header().string(
+                                HttpHeaders.CONTENT_DISPOSITION,
+                                "inline; filename=\"avatar.jpg\""));
+    }
+
+    @Test
+    @DisplayName("Download missing local file returns 404")
+    void downloadFile_localProvider_missingFile_returns404() throws Exception {
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+
+        mockMvc.perform(
+                        get(FILES_URL + "/profiles/does-not-exist.jpg")
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Download with directory traversal returns 400 for local provider")
+    void downloadFile_localProvider_traversal_returns400() throws Exception {
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+
+        mockMvc.perform(
+                        get(FILES_URL + "/../../etc/passwd")
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
@@ -1,11 +1,14 @@
 package com.iyte_yazilim.proje_pazari.presentation.controllers;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -14,6 +17,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
@@ -45,6 +49,9 @@ class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
         Files.write(
                 profilesDir.resolve("avatar.jpg"),
                 "fake-jpeg-bytes".getBytes(StandardCharsets.UTF_8));
+        // The temp directory is shared by every test in the class (it has to be static to feed
+        // the property override), so the fixture's content type must not depend on ordering.
+        Files.deleteIfExists(profilesDir.resolve("avatar.jpg.meta"));
     }
 
     @Test
@@ -115,5 +122,136 @@ class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
                         get(FILES_URL + "/../../etc/passwd")
                                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("Served content carries nosniff and a locked-down CSP")
+    void downloadFile_localProvider_setsContentSecurityHeaders() throws Exception {
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+
+        mockMvc.perform(
+                        get(FILES_URL + "/profiles/avatar.jpg")
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"))
+                .andExpect(
+                        header().string(
+                                        "Content-Security-Policy",
+                                        org.hamcrest.Matchers.containsString(
+                                                "default-src 'none'")));
+    }
+
+    /**
+     * The end-to-end form of the reviewed finding: an upload declaring an allowed content type
+     * while carrying an active extension must not come back as renderable HTML. Goes through the
+     * real upload endpoint, so it covers the stored extension as well as the served headers.
+     */
+    @Test
+    @DisplayName(
+            "Upload declaring an allowed type with an active extension is never served as HTML")
+    void uploadThenDownload_mismatchedActiveExtension_isNotServedAsHtml() throws Exception {
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+        MockMultipartFile upload =
+                new MockMultipartFile(
+                        "file",
+                        "avatar.html",
+                        "image/jpeg",
+                        "<script>alert(1)</script>".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(
+                        multipart(FILES_URL)
+                                .file(upload)
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk());
+
+        String storedName = onlyStoredFileName(tempStorageDir.resolve("uploads"));
+        assertTrue(storedName.endsWith(".jpg"), "stored under an active extension: " + storedName);
+
+        mockMvc.perform(
+                        get(FILES_URL + "/uploads/" + storedName)
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"));
+    }
+
+    /**
+     * Files already on disk under an active extension predate the upload-side fix, so the HTTP
+     * boundary must neutralize them independently.
+     */
+    @Test
+    @DisplayName("Pre-existing file with an active extension is served as an opaque attachment")
+    void downloadFile_localProvider_activeExtensionOnDisk_isNotRenderable() throws Exception {
+        Files.write(
+                tempStorageDir.resolve("profiles").resolve("legacy.html"),
+                "<script>alert(1)</script>".getBytes(StandardCharsets.UTF_8));
+
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+
+        mockMvc.perform(
+                        get(FILES_URL + "/profiles/legacy.html")
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isOk())
+                .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "application/octet-stream"))
+                .andExpect(
+                        header().string(
+                                        HttpHeaders.CONTENT_DISPOSITION,
+                                        org.hamcrest.Matchers.startsWith("attachment")))
+                .andExpect(header().string("X-Content-Type-Options", "nosniff"));
+    }
+
+    @Test
+    @DisplayName("Link inside the storage root pointing outside it is not downloadable")
+    void downloadFile_localProvider_symlinkEscapingRoot_isRejected() throws Exception {
+        Path outsideFile = tempStorageDir.getParent().resolve("outside-secret.txt");
+        Files.write(outsideFile, "host secret".getBytes(StandardCharsets.UTF_8));
+        try {
+            Files.createSymbolicLink(tempStorageDir.resolve("public-link"), outsideFile);
+        } catch (IOException | UnsupportedOperationException e) {
+            org.junit.jupiter.api.Assumptions.assumeTrue(
+                    false, "symbolic links unsupported here: " + e.getMessage());
+        }
+
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+
+        // Reported as missing rather than invalid: the existence check ahead of the read applies
+        // the same containment rule, and answers before the path is resolved for reading.
+        mockMvc.perform(get(FILES_URL + "/public-link").header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("Content type metadata sidecar is not downloadable")
+    void downloadFile_localProvider_metadataSidecar_returns404() throws Exception {
+        String token =
+                createVerifiedUserAndGetToken(
+                        VALID_EMAIL, VALID_PASSWORD, VALID_FIRST_NAME, VALID_LAST_NAME);
+        // Named for a file of its own, so requesting it cannot be satisfied by the shared fixture.
+        Files.write(
+                tempStorageDir.resolve("profiles").resolve("sidecar-probe.jpg.meta"),
+                "contentType=text/html".getBytes(StandardCharsets.UTF_8));
+
+        mockMvc.perform(
+                        get(FILES_URL + "/profiles/sidecar-probe.jpg.meta")
+                                .header("Authorization", "Bearer " + token))
+                .andExpect(status().isNotFound());
+    }
+
+    /** Uploads use a generated name, so the test reads it back from the storage directory. */
+    private String onlyStoredFileName(Path directory) throws IOException {
+        try (var entries = Files.list(directory)) {
+            return entries.map(path -> path.getFileName().toString())
+                    .filter(name -> !name.endsWith(".meta"))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("no file stored in " + directory));
+        }
     }
 }

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
@@ -62,8 +62,8 @@ class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
                 .andExpect(
                         header().string(
-                                HttpHeaders.CONTENT_DISPOSITION,
-                                "inline; filename=\"avatar.jpg\""));
+                                        HttpHeaders.CONTENT_DISPOSITION,
+                                        "inline; filename=\"avatar.jpg\""));
     }
 
     @Test

--- a/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
+++ b/src/test/java/com/iyte_yazilim/proje_pazari/presentation/controllers/LocalStorageDownloadIntegrationTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.iyte_yazilim.proje_pazari.IntegrationTestBase;
+import com.iyte_yazilim.proje_pazari.domain.interfaces.IFileStorageAdapter;
+import com.iyte_yazilim.proje_pazari.domain.models.FileUpload;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -16,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -33,6 +36,7 @@ class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
     private static final String VALID_PASSWORD = "SecurePass123!";
     private static final String VALID_FIRST_NAME = "Local";
     private static final String VALID_LAST_NAME = "Tester";
+    private static final String AVATAR_CONTENT = "fake-jpeg-bytes";
 
     @TempDir static Path tempStorageDir;
 
@@ -42,16 +46,21 @@ class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
         registry.add("storage.local.path", () -> tempStorageDir.toString());
     }
 
+    @Autowired private IFileStorageAdapter storageAdapter;
+
+    /**
+     * Seeded through the real adapter rather than written to disk, so the served content type comes
+     * from the type recorded at store time — the path a genuine upload takes — instead of from the
+     * filename extension. The temp directory is shared by every test in the class (it has to be
+     * static to feed the property override), so the fixture is rewritten before each test.
+     */
     @BeforeEach
     void seedFile() throws Exception {
-        Path profilesDir = tempStorageDir.resolve("profiles");
-        Files.createDirectories(profilesDir);
-        Files.write(
-                profilesDir.resolve("avatar.jpg"),
-                "fake-jpeg-bytes".getBytes(StandardCharsets.UTF_8));
-        // The temp directory is shared by every test in the class (it has to be static to feed
-        // the property override), so the fixture's content type must not depend on ordering.
-        Files.deleteIfExists(profilesDir.resolve("avatar.jpg.meta"));
+        Files.createDirectories(tempStorageDir.resolve("profiles"));
+        byte[] content = AVATAR_CONTENT.getBytes(StandardCharsets.UTF_8);
+        storageAdapter.store(
+                new FileUpload("avatar.jpg", "image/jpeg", content, content.length),
+                "profiles/avatar.jpg");
     }
 
     @Test
@@ -65,8 +74,12 @@ class LocalStorageDownloadIntegrationTest extends IntegrationTestBase {
                         get(FILES_URL + "/profiles/avatar.jpg")
                                 .header("Authorization", "Bearer " + token))
                 .andExpect(status().isOk())
-                .andExpect(content().bytes("fake-jpeg-bytes".getBytes(StandardCharsets.UTF_8)))
+                .andExpect(content().bytes(AVATAR_CONTENT.getBytes(StandardCharsets.UTF_8)))
                 .andExpect(header().string(HttpHeaders.CONTENT_TYPE, "image/jpeg"))
+                .andExpect(
+                        header().string(
+                                        HttpHeaders.CONTENT_LENGTH,
+                                        String.valueOf(AVATAR_CONTENT.length())))
                 .andExpect(
                         header().string(
                                         HttpHeaders.CONTENT_DISPOSITION,


### PR DESCRIPTION
Closes #154.

## Problem

`LocalStorageAdapter.generatePresignedUrl()` returns `/api/v1/files/{path}`, and `FileController.downloadFile()` treated every successful download as a redirect target. With `storage.provider=local` the redirect pointed at the exact route that served the request, so clients would loop on the same URL instead of receiving the file.

## Approach

The download result is represented explicitly instead of assuming every provider yields a redirect URL:

- `StorageDownloadResult` — sealed interface with `RedirectResult(url)` and `InlineResult(content, contentType, filename)`.
- `IFileStorageAdapter.resolveDownload(path, expirationMinutes)` — default implementation wraps `generatePresignedUrl(...)` in a `RedirectResult`, so MinIO/S3 behavior is unchanged and `MinioStorageAdapter` needs no edits.
- `LocalStorageAdapter` overrides it to return inline bytes.
- `FileStorageService.getDownloadResult(...)` validates the path before delegating, preserving the existing validation boundary.
- `FileController` switches exhaustively over the sealed type: 302 + `Location` for redirects, 200 + content type, content length and a disposition for local content.

Content retrieval sits behind the storage interface — no adapter downcast in the controller.

## Note on the base

This branch was originally cut before #151 (the `/{*path}` leading-slash fix) landed on `dev`. On the old base every local download 400'd before reaching the inline code, so the fix was unreachable and its integration test failed. It has been rebased onto current `dev`; the download handler now combines #151's path normalization with the new result type.

## Serving local content safely

Local storage now serves attacker-influenced bytes directly, so the response type and the filesystem boundary both had to be tightened. These changes came out of review on this PR.

**Response type cannot be derived from a client-controlled filename.** Stored extensions are derived from the validated MIME type rather than retained from the uploaded filename; the adapter records the upload-time type in a `.meta` sidecar next to the file and prefers it over extension mapping; and the controller allowlists the types it will render inline, downgrading anything else — HTML, SVG, unknown or malformed values — to `application/octet-stream` with `Content-Disposition: attachment`. `X-Content-Type-Options: nosniff` and a `default-src 'none'` CSP are added as defense in depth. An upload declaring `image/jpeg` while named `avatar.html` therefore cannot come back as renderable HTML at any layer.

**Containment is bound to the operation, not to a pathname.** Checking a path and then opening it is only a snapshot — `Files.write` and `Files.readAllBytes` follow symbolic links, so an entry swapped in between is followed. The new `ContainedFileTree` opens every directory in the path through its parent's descriptor with `NOFOLLOW_LINKS` (`SecureDirectoryStream`) and opens the final entry the same way, so the kernel rejects a link at the moment of use. One rule covers store, read, delete and sidecars: nothing in local storage is reached through a symbolic link, including one that stays inside the root.

Two limits are deliberate and documented on the class:

- Directory creation still resolves a pathname, because Java exposes no descriptor-relative `mkdir`. The result is immediately re-opened through the parent descriptor, so a raced ancestor can at worst leave a stray empty directory — never divert a read or write.
- Hard links are outside the guarantee. A hard link is an ordinary directory entry, so no no-follow open or real-path resolution can tell that the inode also has a name outside the root. Rejecting entries with a link count above one was considered and dropped: snapshot and dedup tooling (`rsync --link-dest`) raises the count on legitimate files and would break every download. Local storage is a development provider and the containment guarantee assumes nothing hostile can write into the storage tree.

`SecureDirectoryStream` is optional in the JDK (present on Linux/macOS, absent on Windows). Where it is missing, the adapter falls back to pathname operations under the same no-follow policy — equivalent against a link already in place, still open to a mid-operation ancestor swap — and logs that at startup.

## Additional fixes folded in

- Removed the now-dead `retrieveAsBytes()`; the traversal guard exists in one place rather than three copies.
- Added `StoredFileNotFoundException` (`ErrorCode.FILE_NOT_FOUND`) so a missing file maps to 404 rather than 400. `DownloadFileHandler` no longer catches and rewraps `FileValidationException` — `DomainException` carries its own `ErrorCode`, which `GlobalExceptionHandler` turns into a localized, user-safe message, whereas rewrapping `e.getMessage()` put the technical message and storage path into the response body.
- Content-Disposition emits the RFC 5987 `filename*` form for non-ASCII names, so Turkish filenames survive the servlet layer's ISO-8859-1 header encoding. The charset is passed conditionally because Spring MIME-encodes the plain `filename` parameter whenever a charset is present, which would obscure ordinary ASCII names.
- Content type resolves from the recorded sidecar first, then from the filename extension. `Files.probeContentType` is no longer consulted: it reads through a pathname and depends on host-specific mime databases, so the served type would vary with where the app runs.

## Testing

`./gradlew test spotlessCheck jacocoTestCoverageVerification` passes in full.

- `LocalStorageDownloadIntegrationTest` — real `LocalStorageAdapter` against a temp directory, no mocked `FileStorageService`. The fixture is seeded **through the adapter**, so the success case asserts the recorded content type rather than extension fallback, along with the original bytes, `Content-Length` and an inline disposition. Also covers 404 for missing files, 400 for traversal, RFC 5987 encoding for a non-ASCII filename, the `nosniff`/CSP headers, an upload whose declared type and active extension disagree, and a pre-existing `.html` file on disk.
- `LocalStorageAdapterUnitTest` — sidecar precedence and reserved-suffix handling; symbolic links rejected for reads, writes, deletes, linked ancestors, sidecars and in-root aliases; a characterization test pinning the documented hard-link boundary; and concurrent entry-swap regressions that hammer the final file, its parent directory and the read path while an attacker thread toggles a link, asserting the external target is never written or served.
- `RemoteStorageAdapterRedirectTest` — hand-written fake adapter (not a Mockito mock, which never runs interface default methods) confirming the default `resolveDownload` still produces a `RedirectResult` and never targets `/api/v1/files/**`.
- `DownloadFileHandlerTest` and `DownloadFilePathNormalizationIntegrationTest` updated for the new result type; #151's normalization coverage is retained.
